### PR TITLE
[#15] PressableAddition 컴포넌트 구현

### DIFF
--- a/src/components/PressableAddition/PressableAddition.styles.tsx
+++ b/src/components/PressableAddition/PressableAddition.styles.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/native';
+
+import {fontPercentage, heightPercentage, widthPercentage} from 'src/utils/ScreenResponse';
+
+export const Container = styled.Pressable({
+  alignSelf: 'flex-start',
+  width: widthPercentage(339),
+  height: heightPercentage(48),
+  alignItems: 'center',
+  borderColor: '#E5E5E5',
+  borderWidth: 2,
+  borderRadius: 4,
+  justifyContent: 'center',
+});
+
+export const PressableAdditionText = styled.Text({
+  color: '#666666',
+  fontStyle: 'normal',
+  fontSize: fontPercentage(14),
+  display: 'flex',
+});

--- a/src/components/PressableAddition/PressableAddition.tsx
+++ b/src/components/PressableAddition/PressableAddition.tsx
@@ -1,0 +1,13 @@
+import React, {PropsWithChildren} from 'react';
+
+import {Container, PressableAdditionText} from './PressableAddition.styles';
+
+const PressableAddition = ({children}: PropsWithChildren) => {
+  return (
+    <Container>
+      <PressableAdditionText>{children}</PressableAdditionText>
+    </Container>
+  );
+};
+
+export default PressableAddition;

--- a/src/components/PressableAddition/index.tsx
+++ b/src/components/PressableAddition/index.tsx
@@ -1,0 +1,3 @@
+import PressableAddition from './PressableAddition';
+
+export default PressableAddition;


### PR DESCRIPTION
## Summary
- 컴포넌트의 Children Props를 통해 내용을 입력할 수 있는 PressableAddition 컴포넌트 구현
- style 관련된 코드는 PressableAddition.styles.tsx에 작성하고, export 되는 코드는 PressableAddition.tsx에 구현함.

## Comment
- ScreenResponse util을 활용하여 반응형 버튼을 제작 하였습니다.
- 이름이 좀 구리긴한데... 딱히 생각나는게 없어서 적당히 작성 했습니다.
- borderWidth와 borderRadius값이 pixel 단위가 먹히지 않아서  android dp단위를 활용하여 제작 하였습니다.

