### PR TITLE
[#36] SquareCard 컴포넌트 구조 수정 및 FastImage Library 적용

### DIFF
--- a/src/components/SquareCard/SquareCard.styles.tsx
+++ b/src/components/SquareCard/SquareCard.styles.tsx
@@ -1,10 +1,18 @@
 import styled from '@emotion/native';
+import {StyleSheet} from 'react-native';
 
 import {heightPercentage, widthPercentage} from 'src/utils/ScreenResponse';
 
-export const SquareCard = styled.View({
+export const CardContainer = styled.View({
   width: widthPercentage(84),
   height: heightPercentage(84),
   borderRadius: 12,
   backgroundColor: '#F6F6F6',
+});
+
+export const styles = StyleSheet.create({
+  photoStyle: {
+    flex: 1,
+    zIndex: 2,
+  },
 });

--- a/src/components/SquareCard/SquareCard.tsx
+++ b/src/components/SquareCard/SquareCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import FastImage from 'react-native-fast-image';
+
+import {CardContainer, styles} from './SquareCard.styles';
+
+interface Props {
+  imgUrl: string;
+}
+
+const SquareCard = ({imgUrl}: Props) => {
+  return (
+    <CardContainer>
+      <FastImage
+        style={styles.photoStyle}
+        resizeMode="cover"
+        source={{
+          uri: imgUrl,
+          //TO-DO (header, priority, etc)
+        }}
+      />
+    </CardContainer>
+  );
+};
+
+export default SquareCard;

--- a/src/components/SquareCard/index.tsx
+++ b/src/components/SquareCard/index.tsx
@@ -1,3 +1,3 @@
-import {SquareCard} from './SquareCard.styles';
+import SquareCard from './SquareCard';
 
 export default SquareCard;


### PR DESCRIPTION
## Summary
- SquareCard 컴포넌트를 구현할 때 Image style을 지정해주지 않아서 다시 만들었습니다.
- RN 기본 컴포넌트인 Image보다 훨씬 성능이 뛰어난 FastImage를 사용하여 개발 하였습니다.

## Comment
- resizeMode를 cover로 고정하는것이 좋을 거 같습니다. cover로 설정시 여백이 남지 않습니다.