### PR TITLE
[#76] 부스 상세 페이지 키워드 박스 영역 UI 구현

### DIFF
--- a/src/components/BoothDetail/KeywordOrganism/KeywordOrganism.styles.tsx
+++ b/src/components/BoothDetail/KeywordOrganism/KeywordOrganism.styles.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/native';
+
+import {BodyText4, SubHeadline2} from 'src/components/utils/Text';
+import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
+import theme from 'src/styles/Theme';
+
+export const Container = styled.View({
+  paddingHorizontal: widthPercentage(18),
+  paddingVertical: heightPercentage(18),
+});
+
+export const TextContainer = styled.View({
+  justifyContent: 'space-between',
+  flexDirection: 'row',
+});
+
+export const KeywordContainer = styled.View({
+  height: heightPercentage(222),
+  justifyContent: 'space-between',
+  marginVertical: heightPercentage(13.5),
+});
+
+export const ButtonWrapper = styled.View({
+  paddingVertical: heightPercentage(6),
+});
+
+export const Headline = styled(SubHeadline2)({
+  color: theme.colors.grayscale[10],
+});
+
+export const NumOfKeyword = styled(SubHeadline2)({
+  color: theme.colors.grayscale[7],
+});
+
+export const ReviewWriteLink = styled(BodyText4)({
+  textDecorationLine: 'underline',
+  color: theme.colors.grayscale[7],
+  alignSelf: 'flex-end',
+});

--- a/src/components/BoothDetail/KeywordOrganism/KeywordOrganism.tsx
+++ b/src/components/BoothDetail/KeywordOrganism/KeywordOrganism.tsx
@@ -1,0 +1,42 @@
+import React, {useState} from 'react';
+import {Text} from 'react-native';
+
+import {
+  ButtonWrapper,
+  Container,
+  Headline,
+  KeywordContainer,
+  NumOfKeyword,
+  ReviewWriteLink,
+  TextContainer,
+} from './KeywordOrganism.styles';
+
+import BoothDetailData from 'src/BoothDetailData';
+import PressableAddition from 'src/components/PressableAddition';
+import KeywordBox from 'src/components/utils/KeywordBox';
+
+const KeywordOrganism = () => {
+  const [data] = useState(BoothDetailData);
+
+  return (
+    <Container>
+      <TextContainer>
+        <Text>
+          <Headline>이 지점 키워드 </Headline>
+          <NumOfKeyword>{data.keyword.total}</NumOfKeyword>
+        </Text>
+        <ReviewWriteLink>나도 리뷰 쓰기</ReviewWriteLink>
+      </TextContainer>
+      <KeywordContainer>
+        {data.keyword.elements.slice(0, 4).map(word => (
+          <KeywordBox {...word} key={word.keyword} />
+        ))}
+      </KeywordContainer>
+      <ButtonWrapper>
+        <PressableAddition>키워드 전체보기</PressableAddition>
+      </ButtonWrapper>
+    </Container>
+  );
+};
+
+export default KeywordOrganism;

--- a/src/components/BoothDetail/KeywordOrganism/index.tsx
+++ b/src/components/BoothDetail/KeywordOrganism/index.tsx
@@ -1,0 +1,3 @@
+import KeywordOrganism from './KeywordOrganism';
+
+export default KeywordOrganism;

--- a/src/components/utils/KeywordBox/KeywordBox.styles.tsx
+++ b/src/components/utils/KeywordBox/KeywordBox.styles.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/native';
+
+import {BodyText1} from '../Text';
+
+import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
+import theme from 'src/styles/Theme';
+
+export const Container = styled.Pressable({
+  paddingHorizontal: widthPercentage(16),
+  paddingVertical: heightPercentage(14),
+  backgroundColor: theme.colors.grayscale[2],
+  borderRadius: 8,
+});
+
+export const TextWrapper = styled.View({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+});
+
+export const Keyword = styled(BodyText1)({
+  color: theme.colors.grayscale[8],
+});
+
+export const Count = styled(BodyText1)({
+  color: theme.colors.grayscale[10],
+});

--- a/src/components/utils/KeywordBox/KeywordBox.tsx
+++ b/src/components/utils/KeywordBox/KeywordBox.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import {Container, Count, Keyword, TextWrapper} from './KeywordBox.styles';
+
+interface Props {
+  keyword: string;
+  count: number;
+}
+
+const KeywordBox = ({keyword, count}: Props) => {
+  return (
+    <Container>
+      <TextWrapper>
+        <Keyword>{keyword}</Keyword>
+        <Count>{count}</Count>
+      </TextWrapper>
+    </Container>
+  );
+};
+
+export default KeywordBox;

--- a/src/components/utils/KeywordBox/index.tsx
+++ b/src/components/utils/KeywordBox/index.tsx
@@ -1,0 +1,3 @@
+import KeywordBox from './KeywordBox';
+
+export default KeywordBox;


### PR DESCRIPTION
## Summary

- 부스 상세 페이지 키워드 박스 영역 UI 구현
- 키워드 박스 유틸 컴포넌트 구현

## Comments

- BoothDetailData를 사용하여 구현했습니다.
- 이전 PR에 BoothDetailData가 있기 때문에, 해당 pr을 빌드하려면 BoothDetailData가 필요합니다.