### PR TITLE
[#78] 부스 상세 페이지 후기 사진 영역 구현

### DIFF
--- a/src/BoothDetailData.ts
+++ b/src/BoothDetailData.ts
@@ -43,12 +43,30 @@ const BoothDetailData = {
   boothPhoto: {
     total: 9999,
     elements: [
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      {
+        id: 1,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
+      {
+        id: 2,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
+      {
+        id: 3,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
+      {
+        id: 4,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
+      {
+        id: 5,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
+      {
+        id: 6,
+        uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_NHQH8W9koZ55iRPtxTaRnbNdQPk8sW1qfQ&usqp=CAU',
+      },
     ],
   },
 };

--- a/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.styles.tsx
+++ b/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.styles.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/native';
+import {StyleSheet} from 'react-native';
+
+import {SubHeadline2} from 'src/components/utils/Text';
+import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
+import theme from 'src/styles/Theme';
+
+export const Container = styled.View({
+  paddingHorizontal: widthPercentage(18),
+  paddingVertical: heightPercentage(18),
+});
+
+export const TextContainer = styled.Text({
+  paddingVertical: heightPercentage(16),
+});
+
+export const Headline = styled(SubHeadline2)({
+  color: theme.colors.grayscale[10],
+});
+
+export const Count = styled(SubHeadline2)({
+  color: theme.colors.grayscale[7],
+});
+
+export const ButtonWrapper = styled.View({
+  paddingVertical: heightPercentage(24),
+});
+
+export const style = StyleSheet.create({
+  fastImage: {
+    height: widthPercentage(111),
+    width: widthPercentage(111),
+    marginRight: widthPercentage(3),
+    marginTop: widthPercentage(3),
+  },
+});

--- a/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.styles.tsx
+++ b/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.styles.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/native';
 import {StyleSheet} from 'react-native';
 
-import {SubHeadline2} from 'src/components/utils/Text';
+import {BodyText3, SubHeadline2} from 'src/components/utils/Text';
 import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
 import theme from 'src/styles/Theme';
 
@@ -26,8 +26,15 @@ export const ButtonWrapper = styled.View({
   paddingVertical: heightPercentage(24),
 });
 
+export const TotalPhoto = styled(BodyText3)({
+  color: theme.colors.grayscale[8],
+});
+
 export const style = StyleSheet.create({
   fastImage: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.grayscale[3],
     height: widthPercentage(111),
     width: widthPercentage(111),
     marginRight: widthPercentage(3),

--- a/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.tsx
+++ b/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.tsx
@@ -1,0 +1,41 @@
+import React, {useState} from 'react';
+import {FlatList} from 'react-native';
+import FastImage from 'react-native-fast-image';
+
+import {
+  ButtonWrapper,
+  Container,
+  Count,
+  Headline,
+  style,
+  TextContainer,
+} from './GridPhotoOrganism.styles';
+
+import BoothDetailData from 'src/BoothDetailData';
+import PressableAddition from 'src/components/PressableAddition';
+import toLocaleString from 'src/utils/toLocaleString';
+
+const GridPhotoOrganism = () => {
+  const [data] = useState(BoothDetailData);
+
+  return (
+    <Container>
+      <TextContainer>
+        <Headline>포톡커들의 사진 </Headline>
+        <Count> {toLocaleString(data.boothPhoto.total)}</Count>
+      </TextContainer>
+      <FlatList
+        data={data.boothPhoto.elements.slice(0, 6)}
+        numColumns={3}
+        renderItem={uri => (
+          <FastImage key={uri.item.id} source={{uri: uri.item.uri}} style={style.fastImage} />
+        )}
+      />
+      <ButtonWrapper>
+        <PressableAddition>사진 더보기</PressableAddition>
+      </ButtonWrapper>
+    </Container>
+  );
+};
+
+export default GridPhotoOrganism;

--- a/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.tsx
+++ b/src/components/BoothDetail/GridPhotoOrganism/GridPhotoOrganism.tsx
@@ -9,6 +9,7 @@ import {
   Headline,
   style,
   TextContainer,
+  TotalPhoto,
 } from './GridPhotoOrganism.styles';
 
 import BoothDetailData from 'src/BoothDetailData';
@@ -28,7 +29,12 @@ const GridPhotoOrganism = () => {
         data={data.boothPhoto.elements.slice(0, 6)}
         numColumns={3}
         renderItem={uri => (
-          <FastImage key={uri.item.id} source={{uri: uri.item.uri}} style={style.fastImage} />
+          <FastImage
+            key={uri.item.id}
+            source={{uri: uri.item.uri}}
+            style={{...style.fastImage, ...{opacity: uri.index === 5 ? 0.5 : 1}}}>
+            {uri.index !== 5 || <TotalPhoto>{data.boothPhoto.elements.length}</TotalPhoto>}
+          </FastImage>
         )}
       />
       <ButtonWrapper>

--- a/src/components/BoothDetail/GridPhotoOrganism/index.tsx
+++ b/src/components/BoothDetail/GridPhotoOrganism/index.tsx
@@ -1,0 +1,3 @@
+import GridPhotoOrganism from './GridPhotoOrganism';
+
+export default GridPhotoOrganism;


### PR DESCRIPTION
## Summary

- 부스 상세 페이지 GridPhotoOrganism 컴포넌트 구현
- data 중 상위 6개만 노출되도록 구현
- 6번째 인덱스에 존재하는 element에 opacity 속성 적용

## Comments

- 정사각형 모양이 유지되어야 하기 때문에, height에 heightPercentage를 적용하지 않고, widthPercentage를 적용했습니다.