### PR TITLE
[#73] 부스 상세 스크린 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,10 +4,11 @@ import {NavigationContainer} from '@react-navigation/native';
 import * as React from 'react';
 import {QueryClient, QueryClientProvider} from 'react-query';
 
-import BoothScreen from 'src/screens/BoothScreen/BoothScreen';
+import RouteBoothScreen from 'src/screens/BoothScreen';
 import MyScreen from 'src/screens/MyScreen/MyScreen';
 import RouteRecommendScreen from 'src/screens/RecommendScreen';
 import StorageScreen from 'src/screens/StorageScreen/StorageScreen';
+import GlobalStyle from 'src/styles/GlobalStyle';
 import theme from 'src/styles/Theme';
 
 export type RootParamList = {
@@ -23,9 +24,9 @@ const App = () => {
   return (
     <QueryClientProvider client={new QueryClient()}>
       <ThemeProvider theme={theme}>
-        <NavigationContainer>
+        <NavigationContainer theme={GlobalStyle}>
           <Tab.Navigator screenOptions={{headerShown: false}}>
-            <Tab.Screen name={'BoothScreen'} component={BoothScreen} />
+            <Tab.Screen name={'BoothScreen'} component={RouteBoothScreen} />
             <Tab.Screen name={'RecommendScreen'} component={RouteRecommendScreen} />
             <Tab.Screen name={'StorageScreen'} component={StorageScreen} />
             <Tab.Screen name={'MyScreen'} component={MyScreen} />

--- a/src/BoothDetailData.ts
+++ b/src/BoothDetailData.ts
@@ -11,10 +11,10 @@ const BoothDetailData = {
   keyword: {
     total: 9999,
     elements: [
-      {title: '깨끗해요', numOfKeyword: 99999},
-      {title: '소품이 다양해요', numOfKeyword: 126},
-      {title: '파우더룸이 잘 되어있어요', numOfKeyword: 50},
-      {title: '인테리어가 멋져요', numOfKeyword: 50},
+      {keyword: '깨끗해요', count: 99999},
+      {keyword: '소품이 다양해요', count: 126},
+      {keyword: '파우더룸이 잘 되어있어요', count: 50},
+      {keyword: '인테리어가 멋져요', count: 50},
     ],
   },
   review: {

--- a/src/screens/BoothScreen/BoothDetailScreen.styles.tsx
+++ b/src/screens/BoothScreen/BoothDetailScreen.styles.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import {DetailScreenProps} from './BoothDetailScreen';
+
+import {PressableLeftArrowIcon} from 'src/components/utils/Pressables/PressableIcons';
+
+export const DetailHeaderStyle = ({navigation}: DetailScreenProps) => {
+  navigation.setOptions({
+    headerLeft: () => <PressableLeftArrowIcon onPress={() => navigation.goBack()} />,
+    title: '',
+  });
+};

--- a/src/screens/BoothScreen/BoothDetailScreen.tsx
+++ b/src/screens/BoothScreen/BoothDetailScreen.tsx
@@ -1,0 +1,31 @@
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import React, {useLayoutEffect} from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+
+import {DetailHeaderStyle} from './BoothDetailScreen.styles';
+
+import {BoothParamList} from '.';
+
+import DescriptionOrganism from 'src/components/BoothDetail/DescriptionOrganism';
+import ImageSliderOrganism from 'src/components/BoothDetail/ImageSliderOrganism';
+import KeywordOrganism from 'src/components/BoothDetail/KeywordOrganism';
+import ReviewOrganism from 'src/components/BoothDetail/ReviewOrganism';
+
+export type DetailScreenProps = NativeStackScreenProps<BoothParamList, 'BoothDetailScreen'>;
+
+const BoothDetailScreen = ({navigation, route}: DetailScreenProps) => {
+  useLayoutEffect(() => {
+    DetailHeaderStyle({navigation, route});
+  });
+
+  return (
+    <ScrollView>
+      <ImageSliderOrganism />
+      <DescriptionOrganism />
+      <KeywordOrganism />
+      <ReviewOrganism />
+    </ScrollView>
+  );
+};
+
+export default BoothDetailScreen;

--- a/src/screens/BoothScreen/index.tsx
+++ b/src/screens/BoothScreen/index.tsx
@@ -1,0 +1,23 @@
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import * as React from 'react';
+
+import BoothDetailScreen from './BoothDetailScreen';
+import BoothScreen from './BoothScreen';
+
+const Stack = createNativeStackNavigator();
+
+export type BoothParamList = {
+  BoothScreen: undefined;
+  BoothDetailScreen: undefined;
+};
+
+const RouteBoothScreen = () => {
+  return (
+    <Stack.Navigator initialRouteName="Booth">
+      <Stack.Screen name="Booth" component={BoothScreen} />
+      <Stack.Screen name="BoothDetail" component={BoothDetailScreen} />
+    </Stack.Navigator>
+  );
+};
+
+export default RouteBoothScreen;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,0 +1,11 @@
+import {DefaultTheme, Theme} from '@react-navigation/native';
+
+const GlobalStyle: Theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: 'white',
+  },
+};
+
+export default GlobalStyle;


### PR DESCRIPTION
## Summary

- 이전 작업에서 구현한 Organism 컴포넌트들을 모아 부스 상세 스크린 구현
- Default Style로 backgroundColor: white 추가를 위해 App.tsx의 NavigationContainer에 theme를 추가함

## Comments

- BoothScreen을 StackNavigation으로 수정하게되어 지도 스크린에 헤더가 생겼습니다.
- 아직 GridPhotoOrganism이 머지되지 않았기 때문에, 머지된 후 코드 추가하여 이번 PR 머지하도록 하겠습니다.
- 스크린 넘어갈 때 BoothId를 넘겨주어야 할 것 같아서, ParamList에 추가하겠습니다.