### PR TITLE
[#115] 포스트 리스트 상세 페이지 API 연동

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -298,6 +298,7 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     implementation("com.google.android.gms:play-services-location:16.0.0")
 
+    implementation project(':react-native-linear-gradient')
 
     implementation 'com.naver.maps:map-sdk:3.15.0'
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,6 +2,8 @@ rootProject.name = 'hot6'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/react-native-gradle-plugin')
+include ':react-native-linear-gradient'
+project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
 
 if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true") {
     include(":ReactAndroid")

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-native-image-crop-picker": "^0.38.0",
     "react-native-image-resizer": "^1.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
+    "react-native-linear-gradient": "^2.6.2",
     "react-native-nmap": "^0.0.66",
     "react-native-permissions": "^3.6.0",
     "react-native-reanimated": "^2.9.1",

--- a/src/apis/getPosts.ts
+++ b/src/apis/getPosts.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+import getApiServer from 'src/utils/getApiServer';
+
+interface Parameter {
+  page?: number;
+  pageSize?: number;
+  tagIdSet: number[];
+}
+
+/*
+  page 파라미터 없을 시 전체 데이터 가져옴
+*/
+const getPosts = async ({page = 0, pageSize = 10, tagIdSet}: Parameter) => {
+  const url = `${getApiServer}/api/v1/post/recommendation?`;
+  const params = `page=${page}&pageSize=${pageSize}&tagIdSet=${tagIdSet.join(',')}`;
+  const response = await axios.get(url + params);
+  const result = response.data;
+
+  return {
+    result,
+    nextPage: page + 1,
+    isLast: false,
+  };
+};
+
+export default getPosts;

--- a/src/apis/getPostsByTag.ts
+++ b/src/apis/getPostsByTag.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+import getApiServer from 'src/utils/getApiServer';
+
+const getPostsByTag = async (tagIdSet: number[]) => {
+  const url = `${getApiServer}/api/v1/post/recommendation?`;
+  const params = `tagIdSet=${tagIdSet.join(',')}`;
+  const response = await axios.get(url + params);
+
+  return response.data;
+};
+
+export default getPostsByTag;

--- a/src/apis/getTagForm.ts
+++ b/src/apis/getTagForm.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+import {Tag} from 'src/types';
+import getApiServer from 'src/utils/getApiServer';
+
+const getTagForm = async (tagType: number): Promise<Tag[][]> => {
+  const tagTypes = [['BRAND'], ['HEAD_COUNT', 'RELATION'], ['CONCEPT', 'SITUATION'], ['FRAME']];
+  const urls = tagTypes[tagType].map(type => `${getApiServer}/api/v1/tag/form?tagType=${type}`);
+  const promises = urls.map(url => axios.get(url));
+  const response = await Promise.all(promises);
+
+  return response.map(({data}) => data);
+};
+
+export default getTagForm;

--- a/src/components/PostListDetail/CardListOrganism/CardListOrganism.styles.tsx
+++ b/src/components/PostListDetail/CardListOrganism/CardListOrganism.styles.tsx
@@ -16,7 +16,7 @@ export const FlatListWrapper = styled.View({
 });
 
 export const PostDetailFlatList = styled.FlatList({
-  height: height - heightPercentage(194),
+  height: height - heightPercentage(145),
 });
 
 export const SortButtonWrapper = styled.Pressable({

--- a/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
+++ b/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
@@ -1,15 +1,25 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
 import {useDispatch} from 'react-redux';
 
 import {Container, FlatListWrapper, PostDetailFlatList} from './CardListOrganism.styles';
+import ListEmptyComponent from './ListEmptyComponent';
 import SortingListHeader from './SortingListHeader';
 
 import RecommendFeedCard from 'src/components/Recommend/FeedCard/RecommendFeedCard';
+import useGetInfinitePosts from 'src/querys/useGetInfinitePosts';
 import {hideTabBar, showTabBar} from 'src/redux/actions/TabBarAction';
 
 const CardListOrganism = () => {
   const dispatch = useDispatch();
+  const {data, fetchNextPage} = useGetInfinitePosts({
+    tagIdSet: [],
+  });
+  const posts = useMemo(() => {
+    return data?.pages.reduce((allOfPosts: any, page: any) => {
+      return [...allOfPosts, ...page.result.content];
+    }, []);
+  }, [data]);
 
   const handleScroll = ({nativeEvent}: NativeSyntheticEvent<NativeScrollEvent>) => {
     const curY = nativeEvent.velocity?.y;
@@ -29,10 +39,12 @@ const CardListOrganism = () => {
     <Container>
       <FlatListWrapper>
         <PostDetailFlatList
+          ListEmptyComponent={ListEmptyComponent}
           numColumns={2}
-          data={[{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}]}
-          renderItem={() => <RecommendFeedCard imgUrl="" />}
+          data={posts?.map(post => ({imgUrl: post.postImageSet[0].imageUrl}))}
+          renderItem={({item}: any) => <RecommendFeedCard imgUrl={item.imgUrl} />}
           onScroll={handleScroll}
+          onEndReached={() => fetchNextPage()}
           ListHeaderComponent={<SortingListHeader>인기순</SortingListHeader>}
         />
       </FlatListWrapper>

--- a/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
+++ b/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {FlatList, NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
+import React, {useEffect} from 'react';
+import {NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
 import {useDispatch} from 'react-redux';
 
 import {Container, FlatListWrapper, PostDetailFlatList} from './CardListOrganism.styles';
@@ -18,6 +18,12 @@ const CardListOrganism = () => {
     }
     dispatch(curY > 0 ? hideTabBar() : showTabBar());
   };
+
+  useEffect(() => {
+    return () => {
+      dispatch(showTabBar());
+    };
+  }, []);
 
   return (
     <Container>

--- a/src/components/PostListDetail/CardListOrganism/ListEmptyComponent.styles.tsx
+++ b/src/components/PostListDetail/CardListOrganism/ListEmptyComponent.styles.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/native';
+
+import {BodyText4, SubHeadline1} from 'src/components/utils/Text';
+import {heightPercentage} from 'src/styles/ScreenResponse';
+import theme from 'src/styles/Theme';
+
+export const Container = styled.View({
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: heightPercentage(400),
+});
+
+export const Headline = styled(SubHeadline1)({
+  color: theme.colors.grayscale[9],
+  marginVertical: heightPercentage(10),
+});
+
+export const SubHeadline = styled(BodyText4)({
+  color: theme.colors.grayscale[7],
+  textAlign: 'center',
+});

--- a/src/components/PostListDetail/CardListOrganism/ListEmptyComponent.tsx
+++ b/src/components/PostListDetail/CardListOrganism/ListEmptyComponent.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import {Container, Headline, SubHeadline} from './ListEmptyComponent.styles';
+
+const ListEmptyComponent = () => {
+  return (
+    <Container>
+      <Headline>필터 검색 결과가 없어요</Headline>
+      <SubHeadline>해당 필터에 대한 검색 결과가 없어요.</SubHeadline>
+      <SubHeadline>필터를 해제하거나 다른 필터를 선택해보세요.</SubHeadline>
+    </Container>
+  );
+};
+
+export default ListEmptyComponent;

--- a/src/components/PostListDetail/FilterOrganism/FilterOrganism.styles.tsx
+++ b/src/components/PostListDetail/FilterOrganism/FilterOrganism.styles.tsx
@@ -7,8 +7,10 @@ export const Container = styled.View({
   paddingLeft: widthPercentage(16),
   paddingBottom: heightPercentage(14),
   paddingTop: heightPercentage(6),
+  paddingRight: widthPercentage(32),
   flexDirection: 'row',
   alignItems: 'center',
+  justifyContent: 'center',
   borderBottomWidth: 1,
   borderBottomColor: theme.colors.grayscale[2],
 });
@@ -20,4 +22,5 @@ export const ChipWrapper = styled.View({
 export const RefreshWrapper = styled.Pressable({
   paddingHorizontal: widthPercentage(16),
   paddingVertical: heightPercentage(13),
+  color: 'transparent',
 });

--- a/src/components/PostListDetail/FilterOrganism/FilterOrganism.styles.tsx
+++ b/src/components/PostListDetail/FilterOrganism/FilterOrganism.styles.tsx
@@ -4,7 +4,7 @@ import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
 import theme from 'src/styles/Theme';
 
 export const Container = styled.View({
-  paddingHorizontal: widthPercentage(16),
+  paddingLeft: widthPercentage(16),
   paddingBottom: heightPercentage(14),
   paddingTop: heightPercentage(6),
   flexDirection: 'row',
@@ -15,4 +15,9 @@ export const Container = styled.View({
 
 export const ChipWrapper = styled.View({
   marginRight: widthPercentage(8),
+});
+
+export const RefreshWrapper = styled.Pressable({
+  paddingHorizontal: widthPercentage(16),
+  paddingVertical: heightPercentage(13),
 });

--- a/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
+++ b/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import {ScrollView} from 'react-native';
 import {useDispatch} from 'react-redux';
 
-import {ChipWrapper, Container} from './FilterOrganism.styles';
+import {ChipWrapper, Container, RefreshWrapper} from './FilterOrganism.styles';
 
 import OptionChip from 'src/components/Chip/OptionChip';
+import {ALL} from 'src/constants/filters';
 import useFilteredItem from 'src/hooks/useFilteredItem';
 import useFilterTag from 'src/hooks/useFilterTag';
+import RefreshIcon from 'src/icons/RefreshIcon';
 import {openFilterSheet, changeFocus, clearFilter} from 'src/redux/actions/PostAction';
 
 const FilterOrganism = () => {
@@ -59,6 +61,9 @@ const FilterOrganism = () => {
           );
         })}
       </ScrollView>
+      <RefreshWrapper onPress={() => dispatch(clearFilter(ALL))}>
+        <RefreshIcon />
+      </RefreshWrapper>
     </Container>
   );
 };

--- a/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
+++ b/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
@@ -6,12 +6,14 @@ import {ChipWrapper, Container} from './FilterOrganism.styles';
 
 import OptionChip from 'src/components/Chip/OptionChip';
 import useFilteredItem from 'src/hooks/useFilteredItem';
+import useFilterTag from 'src/hooks/useFilterTag';
 import {openFilterSheet, changeFocus, clearFilter} from 'src/redux/actions/PostAction';
 
 const FilterOrganism = () => {
   const labels = ['브랜드', '인원', '포즈컨셉', '프레임'];
   const {getCountOfSelected, getFirstSelected} = useFilteredItem();
   const dispatch = useDispatch();
+  const {getFilterTagById} = useFilterTag();
 
   const openFilter = (index: number) => {
     dispatch(changeFocus(index));
@@ -35,7 +37,7 @@ const FilterOrganism = () => {
     if (!countOfSelected) {
       return labels[index];
     }
-    return `${firstSelected?.index} ${countOfSelected}`;
+    return `${getFilterTagById(firstSelected?.index || 0)} ${countOfSelected}`;
   };
 
   return (

--- a/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
+++ b/src/components/PostListDetail/FilterOrganism/FilterOrganism.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ScrollView} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import {useDispatch} from 'react-redux';
 
 import {ChipWrapper, Container, RefreshWrapper} from './FilterOrganism.styles';
@@ -61,9 +62,15 @@ const FilterOrganism = () => {
           );
         })}
       </ScrollView>
-      <RefreshWrapper onPress={() => dispatch(clearFilter(ALL))}>
-        <RefreshIcon />
-      </RefreshWrapper>
+      <LinearGradient
+        start={{x: 0.1, y: 0}}
+        end={{x: 0, y: 0}}
+        colors={['#ffffffff', '#ffffff00']}
+        style={{position: 'absolute', right: 0, top: 0, bottom: 0, alignSelf: 'center'}}>
+        <RefreshWrapper onPress={() => dispatch(clearFilter(ALL))}>
+          <RefreshIcon />
+        </RefreshWrapper>
+      </LinearGradient>
     </Container>
   );
 };

--- a/src/components/PostListDetail/FilterPages/BrandFilter/BrandFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/BrandFilter/BrandFilter.tsx
@@ -5,21 +5,18 @@ import {ChipWrapper} from '../NestedFilterOrganism/NestedFilterOrganism.styles';
 import {Container} from './BrandFilter.styles';
 
 import FilterChip from 'src/components/Chip/FilterChip';
+import {FILTER} from 'src/constants/filters';
+import useGetTagForm from 'src/querys/useGetTagForm';
 import {changeFilteredBrand} from 'src/redux/actions/PostAction';
 import {RootState} from 'src/redux/store';
+import {Tag} from 'src/types';
 
 const BrandFilter = () => {
   const filteredItems = useSelector((state: RootState) => state.postReducer.filteredBrand);
   const dispatch = useDispatch();
-  const brands = [
-    {id: 1, title: '하루필름', count: 999},
-    {id: 2, title: '인생네컷', count: 999},
-    {id: 3, title: '셀픽스', count: 999},
-    {id: 4, title: '포토이즘', count: 999},
-    {id: 5, title: '포토그레이', count: 999},
-    {id: 6, title: '비룸', count: 999},
-    {id: 7, title: '포토시그니처', count: 999},
-  ];
+  const {data} = useGetTagForm(FILTER.BRAND);
+  // @ts-ignore
+  const tags: Tag[][] = (data || []) as Promise<Tag[][]>;
 
   const handlePressChip = (id: number) => () => {
     dispatch(changeFilteredBrand(id));
@@ -27,11 +24,11 @@ const BrandFilter = () => {
 
   return (
     <Container>
-      {brands.map(({id, title, count}) => (
+      {(tags[0] || []).map(({id, title, postCount}) => (
         <ChipWrapper key={id}>
           <FilterChip
             title={title}
-            count={count}
+            count={postCount}
             selected={filteredItems[id]}
             onPress={handlePressChip(id)}
           />

--- a/src/components/PostListDetail/FilterPages/FrameFilter/FrameFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/FrameFilter/FrameFilter.tsx
@@ -5,20 +5,18 @@ import {Container} from '../BrandFilter/BrandFilter.styles';
 import {ChipWrapper} from '../NestedFilterOrganism/NestedFilterOrganism.styles';
 
 import FilterChip from 'src/components/Chip/FilterChip';
+import {FILTER} from 'src/constants/filters';
+import useGetTagForm from 'src/querys/useGetTagForm';
 import {changeFilteredFrame} from 'src/redux/actions/PostAction';
 import {RootState} from 'src/redux/store';
+import {Tag} from 'src/types';
 
 const FrameFilter = () => {
   const filteredItems = useSelector((state: RootState) => state.postReducer.filteredFrame);
   const dispatch = useDispatch();
-  const frames = [
-    {id: 1, title: '깔끔한', count: 999},
-    {id: 2, title: '캐릭터', count: 999},
-    {id: 3, title: '코믹', count: 999},
-    {id: 4, title: '아이돌', count: 999},
-    {id: 5, title: '한정판', count: 999},
-    {id: 6, title: '커스텀', count: 999},
-  ];
+  const {data} = useGetTagForm(FILTER.FRAME);
+  // @ts-ignore
+  const tags: Tag[][] = (data || []) as Promise<Tag[][]>;
 
   const handlePressChip = (id: number) => () => {
     dispatch(changeFilteredFrame(id));
@@ -26,11 +24,11 @@ const FrameFilter = () => {
 
   return (
     <Container>
-      {frames.map(({id, title, count}) => (
+      {(tags[0] || []).map(({id, title, postCount}) => (
         <ChipWrapper key={id}>
           <FilterChip
             title={title}
-            count={count}
+            count={postCount}
             selected={filteredItems[id]}
             onPress={handlePressChip(id)}
           />

--- a/src/components/PostListDetail/FilterPages/HeadcountFilter/HeadcountFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/HeadcountFilter/HeadcountFilter.tsx
@@ -6,27 +6,21 @@ import {ChipWrapper} from '../NestedFilterOrganism/NestedFilterOrganism.styles';
 import {Container} from './HeadcountFilter.styles';
 
 import FilterChip from 'src/components/Chip/FilterChip';
+import {FILTER} from 'src/constants/filters';
+import useGetTagForm from 'src/querys/useGetTagForm';
 import {
   changeFilteredHeadcountNumber,
   changeFilteredHeadcountRelation,
 } from 'src/redux/actions/PostAction';
 import {RootState} from 'src/redux/store';
+import {Tag} from 'src/types';
 
 const HeadcountFilter = () => {
   const {number, relation} = useSelector((state: RootState) => state.postReducer.filteredHeadcount);
   const dispatch = useDispatch();
-  const numOfPeople = [
-    {id: 1, title: '혼자', count: 999},
-    {id: 2, title: '2명', count: 999},
-    {id: 3, title: '3명', count: 999},
-    {id: 4, title: '4명', count: 999},
-    {id: 5, title: '5명 이상', count: 999},
-  ];
-  const relationData = [
-    {id: 1, title: '커플', count: 999},
-    {id: 2, title: '친구', count: 999},
-    {id: 3, title: '가족', count: 999},
-  ];
+  const {data} = useGetTagForm(FILTER.HEADCOUNT);
+  // @ts-ignore
+  const tags: Tag[][] = (data || []) as Promise<Tag[][]>;
 
   const handlePressNumberChip = (id: number) => () => {
     dispatch(changeFilteredHeadcountNumber(id));
@@ -38,11 +32,11 @@ const HeadcountFilter = () => {
   return (
     <Container>
       <NestedFilterOrganism type="인원 수">
-        {numOfPeople.map(({id, title, count}) => (
+        {(tags[0] || []).map(({id, title, postCount}) => (
           <ChipWrapper key={id}>
             <FilterChip
               title={title}
-              count={count}
+              count={postCount}
               selected={number[id]}
               onPress={handlePressNumberChip(id)}
             />
@@ -50,11 +44,11 @@ const HeadcountFilter = () => {
         ))}
       </NestedFilterOrganism>
       <NestedFilterOrganism type="관계">
-        {relationData.map(({id, title, count}) => (
+        {(tags[1] || []).map(({id, title, postCount}) => (
           <ChipWrapper key={id}>
             <FilterChip
               title={title}
-              count={count}
+              count={postCount}
               selected={relation[id]}
               onPress={handlePressRelationChip(id)}
             />

--- a/src/components/PostListDetail/FilterPages/PoseFilter/PoseFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/PoseFilter/PoseFilter.tsx
@@ -6,29 +6,18 @@ import NestedFilterOrganism from '../NestedFilterOrganism';
 import {ChipWrapper} from '../NestedFilterOrganism/NestedFilterOrganism.styles';
 
 import FilterChip from 'src/components/Chip/FilterChip';
+import {FILTER} from 'src/constants/filters';
+import useGetTagForm from 'src/querys/useGetTagForm';
 import {changeFilteredPoseEmotion, changeFilteredPoseSituation} from 'src/redux/actions/PostAction';
 import {RootState} from 'src/redux/store';
+import {Tag} from 'src/types';
 
 const PoseFilter = () => {
   const {emotion, situation} = useSelector((state: RootState) => state.postReducer.filteredPose);
   const dispatch = useDispatch();
-  const emotionData = [
-    {id: 1, title: '코믹', count: 999},
-    {id: 2, title: '예쁜/청순', count: 999},
-    {id: 3, title: '힙한', count: 999},
-    {id: 4, title: '연예인', count: 999},
-    {id: 5, title: '졸업', count: 999},
-  ];
-  const situationData = [
-    {id: 1, title: '졸업', count: 999},
-    {id: 2, title: '생일', count: 999},
-    {id: 3, title: '크리스마스', count: 999},
-    {id: 4, title: '시험끝', count: 999},
-    {id: 5, title: '프로필사진', count: 999},
-    {id: 6, title: '명절', count: 999},
-    {id: 7, title: '웃긴소품', count: 999},
-    {id: 8, title: '공주소품', count: 999},
-  ];
+  const {data} = useGetTagForm(FILTER.POSE);
+  // @ts-ignore
+  const tags: Tag[][] = data || [];
 
   const handlePressEmotionChip = (id: number) => () => {
     dispatch(changeFilteredPoseEmotion(id));
@@ -40,11 +29,11 @@ const PoseFilter = () => {
   return (
     <Container>
       <NestedFilterOrganism type="감정">
-        {emotionData.map(({id, title, count}) => (
+        {(tags[0] || []).map(({id, title, postCount}) => (
           <ChipWrapper key={id}>
             <FilterChip
               title={title}
-              count={count}
+              count={postCount}
               selected={emotion[id]}
               onPress={handlePressEmotionChip(id)}
             />
@@ -52,11 +41,11 @@ const PoseFilter = () => {
         ))}
       </NestedFilterOrganism>
       <NestedFilterOrganism type="상황">
-        {situationData.map(({id, title, count}) => (
+        {(tags[1] || []).map(({id, title, postCount}) => (
           <ChipWrapper key={id}>
             <FilterChip
               title={title}
-              count={count}
+              count={postCount}
               selected={situation[id]}
               onPress={handlePressSituationChip(id)}
             />

--- a/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
+++ b/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
@@ -5,12 +5,15 @@ import {Container, RefreshWrapper} from './FilterSheetFooter.styles';
 
 import {PressableRefreshIcon} from 'src/components/utils/Pressables/PressableIcons';
 import PressableSubmit from 'src/components/utils/Pressables/PressableSubmit';
+import useFilteredItem from 'src/hooks/useFilteredItem';
+import useGetPostsByTag from 'src/querys/useGetPostsByTag';
 import {clearFilter} from 'src/redux/actions/PostAction';
 import {widthPercentage} from 'src/styles/ScreenResponse';
 
 const FilterSheetFooter = () => {
   const dispatch = useDispatch();
-  const data = 9999;
+  const {tagIdSet} = useFilteredItem();
+  const {data} = useGetPostsByTag(tagIdSet);
 
   const handlePressRefresh = () => dispatch(clearFilter());
 
@@ -19,7 +22,9 @@ const FilterSheetFooter = () => {
       <RefreshWrapper onPress={handlePressRefresh}>
         <PressableRefreshIcon onPress={handlePressRefresh} />
       </RefreshWrapper>
-      <PressableSubmit style={{width: widthPercentage(286)}}>{data}개 결과보기</PressableSubmit>
+      <PressableSubmit style={{width: widthPercentage(286)}}>
+        {data === undefined ? '' : `${data.content.length}개 결과보기`}
+      </PressableSubmit>
     </Container>
   );
 };

--- a/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
+++ b/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
@@ -7,7 +7,7 @@ import {PressableRefreshIcon} from 'src/components/utils/Pressables/PressableIco
 import PressableSubmit from 'src/components/utils/Pressables/PressableSubmit';
 import useFilteredItem from 'src/hooks/useFilteredItem';
 import useGetPostsByTag from 'src/querys/useGetPostsByTag';
-import {clearFilter} from 'src/redux/actions/PostAction';
+import {clearFilter, closeFilterSheet} from 'src/redux/actions/PostAction';
 import {widthPercentage} from 'src/styles/ScreenResponse';
 
 const FilterSheetFooter = () => {
@@ -15,7 +15,10 @@ const FilterSheetFooter = () => {
   const {tagIdSet} = useFilteredItem();
   const {data} = useGetPostsByTag(tagIdSet);
 
-  const handlePressRefresh = () => dispatch(clearFilter());
+  const handlePressRefresh = () => {
+    dispatch(clearFilter());
+    dispatch(closeFilterSheet());
+  };
 
   return (
     <Container>

--- a/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
+++ b/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
@@ -22,7 +22,9 @@ const PoseRecommendOrganism = ({children}: PropsWithChildren) => {
       </TitleWrapper>
       <PreviewFourCard data={TestData} onPress={handlePressCard} />
       <ButtonWrapper>
-        <PressableAddition>사진 더보기</PressableAddition>
+        <PressableAddition onPress={() => navigation.navigate('PostListDetail' as never)}>
+          사진 더보기
+        </PressableAddition>
       </ButtonWrapper>
     </OrganismView>
   );

--- a/src/hooks/useFilterTag.ts
+++ b/src/hooks/useFilterTag.ts
@@ -1,0 +1,32 @@
+import {useMemo} from 'react';
+
+import {FILTER} from 'src/constants/filters';
+import useGetTagForm from 'src/querys/useGetTagForm';
+import {Tag} from 'src/types';
+
+const useFilterTag = () => {
+  const filterTag: Promise<Tag[][]>[] = [
+    (useGetTagForm(FILTER.BRAND).data || []) as Promise<Tag[][]>,
+    (useGetTagForm(FILTER.HEADCOUNT).data || []) as Promise<Tag[][]>,
+    (useGetTagForm(FILTER.POSE).data || []) as Promise<Tag[][]>,
+    (useGetTagForm(FILTER.FRAME).data || []) as Promise<Tag[][]>,
+  ];
+  const parsedFilterTag = useMemo(() => {
+    return filterTag.reduce((map: {[id: number]: string}, filters: any) => {
+      filters.forEach((tags: Tag[]) => {
+        tags.forEach(tag => {
+          map[tag.id] = tag.title;
+        });
+      });
+      return map;
+    }, {});
+  }, [filterTag]);
+
+  const getFilterTagById = (id: number) => {
+    return parsedFilterTag[id];
+  };
+
+  return {getFilterTagById};
+};
+
+export default useFilterTag;

--- a/src/hooks/useFilteredItem.ts
+++ b/src/hooks/useFilteredItem.ts
@@ -48,8 +48,20 @@ const useFilteredItem = () => {
       return {type, index: selected[0]};
     }, null);
   };
+  const getTagIdSet = () => {
+    return items.reduce((set: any, filters) => {
+      filters.forEach(({filtered}) => {
+        set = [...set, ...Object.keys(filtered).filter(key => filtered[key])];
+      });
+      return set;
+    }, []);
+  };
+  const tagIdSet = useMemo(
+    () => getTagIdSet(),
+    [filteredBrand, filteredHeadcount, filteredPose, filteredFrame],
+  );
 
-  return {getCountOfSelected, getFirstSelected};
+  return {getCountOfSelected, getFirstSelected, tagIdSet};
 };
 
 export default useFilteredItem;

--- a/src/querys/useGetInfinitePosts.ts
+++ b/src/querys/useGetInfinitePosts.ts
@@ -1,0 +1,23 @@
+import {useInfiniteQuery} from 'react-query';
+
+import getInfinitePosts from 'src/apis/getPosts';
+
+interface Parameter {
+  page?: number;
+  pageSize?: number;
+  tagIdSet: number[];
+}
+
+const useGetInfinitePosts = ({tagIdSet}: Parameter) => {
+  return useInfiniteQuery(
+    ['posts'],
+    ({pageParam = 0}) => getInfinitePosts({page: pageParam, tagIdSet}),
+    {
+      getNextPageParam: lastPage => {
+        return lastPage.nextPage;
+      },
+    },
+  );
+};
+
+export default useGetInfinitePosts;

--- a/src/querys/useGetPostsByTag.ts
+++ b/src/querys/useGetPostsByTag.ts
@@ -1,0 +1,14 @@
+import {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+
+import getPostsByTag from 'src/apis/getPostsByTag';
+import {Recommendation} from 'src/types';
+
+const useGetPostsByTag = (tagIdSet: number[]) => {
+  return useQuery<Recommendation, AxiosError, Recommendation, [string, number[]]>(
+    ['post', tagIdSet],
+    ({queryKey}) => getPostsByTag(queryKey[1]),
+  );
+};
+
+export default useGetPostsByTag;

--- a/src/querys/useGetTagForm.ts
+++ b/src/querys/useGetTagForm.ts
@@ -1,0 +1,14 @@
+import {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+
+import getTagForm from 'src/apis/getTagForm';
+import {Tag} from 'src/types';
+
+const useGetTagForm = (tagType: number) => {
+  return useQuery<Promise<Tag[][]>, AxiosError, Promise<Tag[][]>, [string, number]>(
+    ['tag', tagType],
+    ({queryKey}) => getTagForm(queryKey[1]),
+  );
+};
+
+export default useGetTagForm;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,13 @@
+export interface PostTag {
+  tag: {
+    id: number;
+    title: string;
+    reviewCount: number;
+    postCount: number;
+    tagType: string;
+  };
+}
+
 export interface Post {
   id: number;
   title: string;
@@ -6,9 +16,18 @@ export interface Post {
   status: string;
   createdAt: string;
   updatedAt: string;
-  postTagSet: Tag[];
+  postTagSet: PostTag[];
   postImageSet: PostImage[];
   user: User;
+}
+
+export interface Recommendation {
+  content: Post[];
+  totalPages: number;
+  numberOfElement: number;
+  size: number;
+  number: number;
+  sort: any;
 }
 
 export interface Tag {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -12,13 +12,13 @@ export interface Post {
 }
 
 export interface Tag {
-  tag: {
-    id: 2;
-    title: string;
-    reviewCount: number;
-    postCount: number;
-    isPhotoBooth: boolean;
-  };
+  id: number;
+  title: string;
+  keyword: string;
+  photoBoothCount: number;
+  reviewCount: number;
+  postCount: number;
+  tagType: string;
 }
 
 export interface PostImage {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6993,6 +6993,11 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
+react-native-linear-gradient@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.6.2.tgz#56598a76832724b2afa7889747635b5c80948f38"
+  integrity sha512-Z8Xxvupsex+9BBFoSYS87bilNPWcRfRsGC0cpJk72Nxb5p2nEkGSBv73xZbEHnW2mUFvP+huYxrVvjZkr/gRjQ==
+
 react-native-nmap@^0.0.66:
   version "0.0.66"
   resolved "https://registry.npmjs.org/react-native-nmap/-/react-native-nmap-0.0.66.tgz"


### PR DESCRIPTION
## Summary

- 태그 목록 API 요청을 통해 내려 받음.
- 선택된 필터 태그 중 가장 첫번째 필터 태그의 title을 포스트 리스트 상세 상단 칩에 표시하도록 구현.
- 필터 선택 시 백엔드로부터 내려 받을 수 있는 데이터가 몇 개인지 submit 버튼에 알려주도록 구현
- refresh 버튼에 gradient 적용

## Comments

- 다음 작업은 상세 페이지 수정이나 포스트 리스트 상세 인기순 정렬 구현할 것 같습니다.
- pod install 하고, 아래 링크 따라 적용해주세여
- https://github.com/react-native-linear-gradient/react-native-linear-gradient#linking-for-react-native--059-only