### PR TITLE
[#170] 추천 & 찜 목록 스크린 좋아요 기능 구현

### DIFF
--- a/src/apis/getAccessToken.ts
+++ b/src/apis/getAccessToken.ts
@@ -3,9 +3,13 @@ import axios from 'axios';
 import getApiServer from 'src/utils/getApiServer';
 
 const getAccessToken = async (refreshToken: string) => {
-  const url = `${getApiServer}/api/v1/user/token/refresh`;
-  const response = await axios.get(url, {headers: {'refresh-token': refreshToken}});
-  return response.headers['access-token'];
+  try {
+    const url = `${getApiServer}/api/v1/user/token/refresh`;
+    const response = await axios.get(url, {headers: {'refresh-token': refreshToken}});
+    return response.headers['access-token'];
+  } catch (error) {
+    return Promise.reject(error);
+  }
 };
 
 export default getAccessToken;

--- a/src/apis/getPosts.ts
+++ b/src/apis/getPosts.ts
@@ -1,27 +1,24 @@
-import axios from 'axios';
-
+import AxiosInstance from 'src/components/utils/Interceptor';
 import getApiServer from 'src/utils/getApiServer';
 
 interface Parameter {
   page?: number;
   pageSize?: number;
-  tagIdSet: number[];
+  userId?: string;
+  order: string;
 }
 
-/*
-  page 파라미터 없을 시 전체 데이터 가져옴
-*/
-const getPosts = async ({page = 0, pageSize = 10, tagIdSet}: Parameter) => {
-  const url = `${getApiServer}/api/v1/post/recommendation?`;
-  const params = `page=${page}&pageSize=${pageSize}&tagIdSet=${tagIdSet.join(',')}`;
-  const response = await axios.get(url + params);
-  const result = response.data;
+const getPosts = async ({page = 0, pageSize = 10, order, userId}: Parameter) => {
+  try {
+    const url = `${getApiServer}/api/v1/post?`;
+    const params =
+      `page=${page}&pageSize=${pageSize}&order=${order}` + (userId ? `&userId=${userId}` : '');
+    const response = await AxiosInstance.get(url + params);
 
-  return {
-    result,
-    nextPage: page + 1,
-    isLast: false,
-  };
+    return response.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
 };
 
 export default getPosts;

--- a/src/apis/getPostsByTag.ts
+++ b/src/apis/getPostsByTag.ts
@@ -2,12 +2,25 @@ import axios from 'axios';
 
 import getApiServer from 'src/utils/getApiServer';
 
-const getPostsByTag = async (tagIdSet: number[]) => {
-  const url = `${getApiServer}/api/v1/post/recommendation?`;
-  const params = `tagIdSet=${tagIdSet.join(',')}`;
-  const response = await axios.get(url + params);
+interface Parameter {
+  page?: number;
+  pageSize?: number;
+  order: string;
+  tagIdSet: number[];
+}
 
-  return response.data;
+const getPostsByTag = async ({page = 0, pageSize = 10, tagIdSet, order}: Parameter) => {
+  try {
+    const url = `${getApiServer}/api/v1/post/recommendation?`;
+    const params = `page=${page}&pageSize=${pageSize}&order=${order}&tagIdSet=${tagIdSet.join(
+      ',',
+    )}`;
+    const response = await axios.get(url + params);
+
+    return response.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
 };
 
 export default getPostsByTag;

--- a/src/apis/getUser.ts
+++ b/src/apis/getUser.ts
@@ -5,7 +5,6 @@ const getUser = async () => {
     const result = await AxiosInstance.get('/api/v1/user');
     return result.data;
   } catch (error) {
-    console.error(error);
     return Promise.reject(error);
   }
 };

--- a/src/apis/getUserLike.ts
+++ b/src/apis/getUserLike.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const getUserLike = async () => {
+  try {
+    const result = await AxiosInstance.get('/api/v1/user/like');
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default getUserLike;

--- a/src/apis/getUserLikeBooth.ts
+++ b/src/apis/getUserLikeBooth.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const getUserLikeBooth = async () => {
+  try {
+    const result = await AxiosInstance.get('/api/v1/user/like/photo-booth');
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default getUserLikeBooth;

--- a/src/apis/getUserLikeImage.ts
+++ b/src/apis/getUserLikeImage.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const getUserLikeImage = async () => {
+  try {
+    const result = await AxiosInstance.get('/api/v1/user/like/image');
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default getUserLikeImage;

--- a/src/apis/googleLoginBridge.ts
+++ b/src/apis/googleLoginBridge.ts
@@ -29,7 +29,6 @@ const googleLoginBridge = async (): Promise<LoginParam> => {
     } else {
       Alert.alert('로그인 도중 오류가 발생했습니다.');
     }
-    console.log(statusCodes);
     return Promise.reject(error);
   }
 };

--- a/src/apis/mutatePostLike.ts
+++ b/src/apis/mutatePostLike.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const mutatePostLike = async (id: number) => {
+  try {
+    const result = await AxiosInstance.post(`/api/v1/post/${id}/like`);
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default mutatePostLike;

--- a/src/apis/mutatePostLike.ts
+++ b/src/apis/mutatePostLike.ts
@@ -5,6 +5,7 @@ const mutatePostLike = async (id: number) => {
     const result = await AxiosInstance.post(`/api/v1/post/${id}/like`);
     return result.data;
   } catch (error) {
+    console.error(error.response);
     return Promise.reject(error);
   }
 };

--- a/src/apis/mutateReviewImageLike.ts
+++ b/src/apis/mutateReviewImageLike.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const mutateReviewImageLike = async (id: number) => {
+  try {
+    const result = await AxiosInstance.post(`/api/v1/review/image/${id}/like`);
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default mutateReviewImageLike;

--- a/src/components/Recommend/FeedCard/RecommendFeedCard.tsx
+++ b/src/components/Recommend/FeedCard/RecommendFeedCard.tsx
@@ -1,26 +1,33 @@
 import React from 'react';
 import {PressableProps} from 'react-native';
 import FastImage from 'react-native-fast-image';
+import {useSelector} from 'react-redux';
 
 import {FeedCardContainer, IconContainer, styles} from './RecommendFeedCard.styles';
 
 import LikeButton from 'src/components/utils/Button/LikeButton/LikeButton';
+import {RootState} from 'src/redux/store';
 
-type Props = {imgUrl: string} & PressableProps;
+interface Props extends PressableProps {
+  imgUrl: string;
+  onLike: () => void;
+  isLike: boolean;
+}
 
-const RecommendFeedCard = ({imgUrl, ...props}: Props) => {
+const RecommendFeedCard = ({imgUrl, onLike, isLike, ...props}: Props) => {
+  const data = useSelector((state: RootState) => state.userReducer);
+  const handleLike = () => {
+    if (!data.isLoggedIn) {
+      return;
+    }
+    onLike();
+  };
+
   return (
     <FeedCardContainer {...props}>
-      <FastImage
-        style={styles.photoStyle}
-        resizeMode="cover"
-        source={{
-          uri: imgUrl,
-          //TO-DO (header, priority, etc)
-        }}
-      />
+      <FastImage style={styles.photoStyle} resizeMode="cover" source={{uri: imgUrl}} />
       <IconContainer>
-        <LikeButton />
+        <LikeButton onPress={handleLike} isActive={isLike} />
       </IconContainer>
     </FeedCardContainer>
   );

--- a/src/components/Recommend/FrameOrganism/FrameOrganism.tsx
+++ b/src/components/Recommend/FrameOrganism/FrameOrganism.tsx
@@ -12,28 +12,16 @@ import {
   SubTitleText,
 } from './FrameOrganism.styles';
 
-import {TestData} from 'src/TestData';
-
-export interface Props {
-  data: ReadonlyArray<renderItemList['item']>;
-}
-
-export type renderItemList = {
-  item: {
-    url: string;
-    id: string;
-    title: string;
-  };
-};
+import useGetInfinitePosts from 'src/querys/useGetInfinitePosts';
 
 const FrameRecommendOrganism = () => {
+  const {data} = useGetInfinitePosts({tagIdSet: [41], order: 'popular'});
   const navigation = useNavigation();
 
   const handlePressCard = (id: number) => () => {
     navigation.navigate('RecommendDetail' as never, {postId: id} as never);
   };
 
-  //TO-DO data fetching
   return (
     <OrganismView>
       <TitleWrapper>
@@ -43,7 +31,12 @@ const FrameRecommendOrganism = () => {
         </TextnIconWrapper>
         <SubTitleText>요즘 포톡커들이 많이 찾는 프레임이에요</SubTitleText>
       </TitleWrapper>
-      <RecommendPreviewFourCard data={TestData} onPress={handlePressCard} />
+      {!!data && (
+        <RecommendPreviewFourCard
+          data={data.pages.flat().map(response => response.content) as any}
+          onPress={handlePressCard}
+        />
+      )}
       <ButtonPressable onPress={() => navigation.navigate('PostListDetail' as never)}>
         <ButtonText>캐릭터 프레임 더보기</ButtonText>
       </ButtonPressable>

--- a/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
+++ b/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
@@ -13,16 +13,18 @@ import {
   TitleWrapper,
 } from './PoseOrganism.styles';
 
-import {TestData} from 'src/TestData';
+import useGetPosts from 'src/querys/useGetPosts';
 
 const PoseRecommendOrganism = () => {
+  const {data} = useGetPosts({order: 'popular'});
   const navigation = useNavigation();
 
   const handlePressCard = (id: number) => () => {
     navigation.navigate('RecommendDetail' as never, {postId: id} as never);
   };
 
-  //TO-DO data fetching
+  // console.log(data?.pages.flatMap(response => response.content).map(v => v.id));
+
   return (
     <OrganismView>
       <TitleWrapper>
@@ -32,7 +34,12 @@ const PoseRecommendOrganism = () => {
         </TextnIconWrapper>
         <SubTitleText>인기있는 포톡커의 사진을 확인해보세요</SubTitleText>
       </TitleWrapper>
-      <PreviewFourCard data={TestData} onPress={handlePressCard} />
+      {!!data && (
+        <PreviewFourCard
+          data={data.pages.flatMap(response => response.content) as any}
+          onPress={handlePressCard}
+        />
+      )}
       <ButtonPressable onPress={() => navigation.navigate('PostListDetail' as never)}>
         <ButtonText>인기 사진 더보기</ButtonText>
       </ButtonPressable>

--- a/src/components/Recommend/PreviewSixCard/RecommendPreviewFourCard.tsx
+++ b/src/components/Recommend/PreviewSixCard/RecommendPreviewFourCard.tsx
@@ -1,8 +1,10 @@
 import React, {useMemo} from 'react';
+import {useQueryClient} from 'react-query';
 
 import RecommendFeedCard from '../FeedCard';
 import {PreviewFourCardView} from './RecommendPreviewFourCard.styles';
 
+import useMutatePostLike from 'src/querys/useMutatePostLike';
 import {Post} from 'src/types';
 
 interface Props {
@@ -13,17 +15,30 @@ interface Props {
 type onPressFeedCardHandler = (id: number) => () => void;
 
 const RecommendPreviewFourCard = ({data, onPress}: Props) => {
+  const queryClient = useQueryClient();
+  const {mutate} = useMutatePostLike();
   const fourPosts = useMemo(() => data.slice(0, 6), [data]);
 
   return (
     <PreviewFourCardView>
-      {fourPosts.map(({id, postImageSet}) => (
-        <RecommendFeedCard
-          imgUrl={postImageSet[0].imageUrl}
-          key={id}
-          {...(onPress ? {onPress: onPress(id)} : {})}
-        />
-      ))}
+      {fourPosts.flatMap(
+        ({id, postImageSet, like}) =>
+          !!id && (
+            <RecommendFeedCard
+              key={id}
+              imgUrl={postImageSet[0].imageUrl}
+              isLike={like}
+              onLike={() => {
+                mutate(id, {
+                  onSuccess: () => {
+                    queryClient.invalidateQueries(['post']);
+                  },
+                });
+              }}
+              {...(onPress ? {onPress: onPress(id)} : {})}
+            />
+          ),
+      )}
     </PreviewFourCardView>
   );
 };

--- a/src/components/Recommend/PreviewSixCard/RecommendPreviewFourCard.tsx
+++ b/src/components/Recommend/PreviewSixCard/RecommendPreviewFourCard.tsx
@@ -32,6 +32,7 @@ const RecommendPreviewFourCard = ({data, onPress}: Props) => {
                 mutate(id, {
                   onSuccess: () => {
                     queryClient.invalidateQueries(['post']);
+                    queryClient.invalidateQueries(['userLike']);
                   },
                 });
               }}

--- a/src/components/RecommendDetail/DiffOrganism/DiffOrganism.tsx
+++ b/src/components/RecommendDetail/DiffOrganism/DiffOrganism.tsx
@@ -19,8 +19,12 @@ const RecommendDetailDiffOrganism = ({id}: Props) => {
     <Container>
       <TitleContainer>
         <SubHeadline2>
-          <Title>{data?.user.email}님의 다른 사진 </Title>
-          <NumOfDiff> 33</NumOfDiff>
+          {!!data && (
+            <>
+              <Title>{data?.user.email}님의 다른 사진 </Title>
+              <NumOfDiff> 33</NumOfDiff>
+            </>
+          )}
         </SubHeadline2>
         <IconWrapper>
           <PressableRightArrowIcon />

--- a/src/components/Record/RecordOrganism/RecordOrganism.styles.tsx
+++ b/src/components/Record/RecordOrganism/RecordOrganism.styles.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/native';
+import {StyleSheet} from 'react-native';
 
-import {heightPercentage} from 'src/styles/ScreenResponse';
+import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
 
 export const NickNameContainer = styled.View({
   width: '100%',
@@ -14,12 +15,25 @@ export const SlideViewContainer = styled.View({
 });
 
 export const PostFlatList = styled.FlatList({
-  marginBottom: heightPercentage(250),
+  marginBottom: heightPercentage(170),
   alignSelf: 'center',
 });
 
 export const ReviewFlatList = styled.FlatList({
   width: '100%',
-  marginBottom: heightPercentage(250),
+  marginBottom: heightPercentage(170),
   alignSelf: 'center',
+});
+
+export const CardWrapper = styled.View({
+  paddingHorizontal: widthPercentage(5.5),
+  paddingVertical: heightPercentage(16),
+});
+
+export const style = StyleSheet.create({
+  recordFeedCard: {
+    width: widthPercentage(166),
+    height: heightPercentage(250),
+    borderRadius: 4,
+  },
 });

--- a/src/components/Record/RecordOrganism/RecordOrganism.tsx
+++ b/src/components/Record/RecordOrganism/RecordOrganism.tsx
@@ -1,12 +1,18 @@
 import React, {useState} from 'react';
 import {View} from 'react-native';
+import FastImage from 'react-native-fast-image';
 import {useSelector} from 'react-redux';
 
 import NickNameView from '../NickNameView';
 import RecordHeader from '../RecordHeader';
-import {PostFlatList, ReviewFlatList, SlideViewContainer} from './RecordOrganism.styles';
+import {
+  CardWrapper,
+  PostFlatList,
+  ReviewFlatList,
+  SlideViewContainer,
+  style,
+} from './RecordOrganism.styles';
 
-import RecommendFeedCard from 'src/components/Recommend/FeedCard/RecommendFeedCard';
 import LineSlideView from 'src/components/utils/LineSlideView';
 import NotLoginContainer from 'src/components/utils/NotLoginContainer';
 import ReviewSummary from 'src/components/utils/ReviewSummary';
@@ -18,8 +24,8 @@ const RecordOrganism = () => {
   const [focus, setFocus] = useState(0);
   const {data} = useGetUserList();
   const slideViewItems = [
-    {name: '사진', count: data?.postList.length},
-    {name: '부스 리뷰', count: data?.reviewList.length},
+    {name: '사진', count: !data ? 0 : data.postList.length},
+    {name: '부스 리뷰', count: !data ? 0 : data.reviewList.length},
   ];
   return (
     <View>
@@ -33,7 +39,12 @@ const RecordOrganism = () => {
                 numColumns={2}
                 data={data?.postList}
                 renderItem={({item}: any) => (
-                  <RecommendFeedCard imgUrl={item.postImageSet[0].imageUrl} key={item.id} />
+                  <CardWrapper>
+                    <FastImage
+                      source={{uri: item.postImageSet[0].imageUrl}}
+                      style={style.recordFeedCard}
+                    />
+                  </CardWrapper>
                 )}
               />
               <ReviewFlatList

--- a/src/components/Storage/PhotoOrganism/PhotoOrganism.styles.tsx
+++ b/src/components/Storage/PhotoOrganism/PhotoOrganism.styles.tsx
@@ -1,5 +1,17 @@
 import styled from '@emotion/native';
+import {Dimensions, StyleSheet} from 'react-native';
+
+import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
+
+const {width, height} = Dimensions.get('window');
 
 export const Container = styled.View({
   alignItems: 'center',
+});
+
+export const style = StyleSheet.create({
+  flatList: {
+    height: height - heightPercentage(215),
+    width: width - widthPercentage(21),
+  },
 });

--- a/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
+++ b/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
@@ -5,17 +5,20 @@ import {Container} from './PhotoOrganism.styles';
 
 import FeedCard from 'src/components/Recommend/FeedCard';
 import {heightPercentage} from 'src/styles/ScreenResponse';
+import {UserLikeImage} from 'src/types';
 
-const PhotoOrganism = () => {
-  const data = [{}, {}, {}, {}, {}, {}, {}, {}];
+interface Props {
+  photoList: UserLikeImage[];
+}
 
+const PhotoOrganism = ({photoList}: Props) => {
   return (
     <Container>
       <FlatList
-        data={data}
+        data={photoList}
         numColumns={2}
         style={{height: Dimensions.get('window').height - heightPercentage(215)}}
-        renderItem={({index}) => <FeedCard key={index} imgUrl="" />}
+        renderItem={({index, item}) => <FeedCard key={index} imgUrl={item.imageUrl} />}
       />
     </Container>
   );

--- a/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
+++ b/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import {Dimensions, FlatList} from 'react-native';
+import {FlatList} from 'react-native';
+import {useQueryClient} from 'react-query';
 
-import {Container} from './PhotoOrganism.styles';
+import {Container, style} from './PhotoOrganism.styles';
 
 import FeedCard from 'src/components/Recommend/FeedCard';
 import useMutatePostLike from 'src/querys/useMutatePostLike';
 import useMutateReviewImageLike from 'src/querys/useMutateReviewImageLike';
-import {heightPercentage} from 'src/styles/ScreenResponse';
 import {UserLikeImage} from 'src/types';
 
 interface Props {
@@ -14,12 +14,18 @@ interface Props {
 }
 
 const PhotoOrganism = ({photoList}: Props) => {
+  const queryClient = useQueryClient();
   const {mutate: likePost} = useMutatePostLike();
   const {mutate: likeReview} = useMutateReviewImageLike();
 
   const handleLike = (type: string, id: number) => () => {
     if (type === 'POST') {
-      likePost(id);
+      likePost(id, {
+        onSuccess: () => {
+          queryClient.invalidateQueries(['post']);
+          queryClient.invalidateQueries(['userLike']);
+        },
+      });
     }
     if (type === 'REVIEW') {
       likeReview(id);
@@ -31,7 +37,7 @@ const PhotoOrganism = ({photoList}: Props) => {
       <FlatList
         data={photoList}
         numColumns={2}
-        style={{height: Dimensions.get('window').height - heightPercentage(215)}}
+        style={style.flatList}
         renderItem={({index, item}) => (
           <FeedCard
             key={index}

--- a/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
+++ b/src/components/Storage/PhotoOrganism/PhotoOrganism.tsx
@@ -4,6 +4,8 @@ import {Dimensions, FlatList} from 'react-native';
 import {Container} from './PhotoOrganism.styles';
 
 import FeedCard from 'src/components/Recommend/FeedCard';
+import useMutatePostLike from 'src/querys/useMutatePostLike';
+import useMutateReviewImageLike from 'src/querys/useMutateReviewImageLike';
 import {heightPercentage} from 'src/styles/ScreenResponse';
 import {UserLikeImage} from 'src/types';
 
@@ -12,13 +14,32 @@ interface Props {
 }
 
 const PhotoOrganism = ({photoList}: Props) => {
+  const {mutate: likePost} = useMutatePostLike();
+  const {mutate: likeReview} = useMutateReviewImageLike();
+
+  const handleLike = (type: string, id: number) => () => {
+    if (type === 'POST') {
+      likePost(id);
+    }
+    if (type === 'REVIEW') {
+      likeReview(id);
+    }
+  };
+
   return (
     <Container>
       <FlatList
         data={photoList}
         numColumns={2}
         style={{height: Dimensions.get('window').height - heightPercentage(215)}}
-        renderItem={({index, item}) => <FeedCard key={index} imgUrl={item.imageUrl} />}
+        renderItem={({index, item}) => (
+          <FeedCard
+            key={index}
+            imgUrl={item.imageUrl}
+            onLike={handleLike(item.type, item.id)}
+            isLike={item.like}
+          />
+        )}
       />
     </Container>
   );

--- a/src/components/Storage/SwipeOrganism/SwipeOrganism.tsx
+++ b/src/components/Storage/SwipeOrganism/SwipeOrganism.tsx
@@ -4,17 +4,19 @@ import {View} from 'react-native';
 import PhotoOrganism from '../PhotoOrganism';
 
 import LineSlideView from 'src/components/utils/LineSlideView';
+import useGetUserLike from 'src/querys/useGetUserLike';
 
 const SwipeOrganism = () => {
   const [index, setIndex] = useState(0);
+  const {data} = useGetUserLike();
   const items = [
-    {name: '사진', count: 40},
-    {name: '부스', count: 26},
+    {name: '사진', count: !data ? 0 : data.imageList.length},
+    {name: '부스', count: !data ? 0 : data.photoBoothList.length},
   ];
 
   return (
     <LineSlideView items={items} index={index} setIndex={setIndex}>
-      <PhotoOrganism />
+      {!!data && <PhotoOrganism photoList={data.imageList} />}
       <View />
     </LineSlideView>
   );

--- a/src/components/utils/Button/LikeButton/LikeButton.tsx
+++ b/src/components/utils/Button/LikeButton/LikeButton.tsx
@@ -4,11 +4,18 @@ import {PressableProps} from 'react-native';
 import {Container} from './LikeButton.styles';
 
 import LikeHeartIcon from 'src/icons/LikeHeartIcon';
+import theme from 'src/styles/Theme';
 
-const LikeButton = (props: PressableProps) => {
+interface Props extends PressableProps {
+  isActive: boolean;
+}
+
+const LikeButton = (props: Props) => {
   return (
     <Container {...props}>
-      <LikeHeartIcon />
+      <LikeHeartIcon
+        color={props.isActive ? theme.colors.primary[2].normal : theme.colors.grayscale[0]}
+      />
     </Container>
   );
 };

--- a/src/components/utils/Interceptor/index.tsx
+++ b/src/components/utils/Interceptor/index.tsx
@@ -55,7 +55,7 @@ const Interceptor = ({children}: PropsWithChildren<{}>) => {
         return Promise.reject(error);
       },
     );
-  }, []);
+  }, [accessToken]);
 
   return <>{children}</>;
 };

--- a/src/querys/useGetInfinitePosts.ts
+++ b/src/querys/useGetInfinitePosts.ts
@@ -1,21 +1,27 @@
+import {AxiosError} from 'axios';
 import {useInfiniteQuery} from 'react-query';
 
-import getInfinitePosts from 'src/apis/getPosts';
+import getPostsByTag from 'src/apis/getPostsByTag';
+import {Post, ServerResponse} from 'src/types';
 
 interface Parameter {
   page?: number;
   pageSize?: number;
   tagIdSet: number[];
+  order: string;
 }
 
-const useGetInfinitePosts = ({tagIdSet}: Parameter) => {
-  return useInfiniteQuery(
-    ['posts'],
-    ({pageParam = 0}) => getInfinitePosts({page: pageParam, tagIdSet}),
+const useGetInfinitePosts = ({tagIdSet, order}: Parameter) => {
+  return useInfiniteQuery<
+    ServerResponse<Post>,
+    AxiosError,
+    ServerResponse<Post>,
+    [string, string, string]
+  >(
+    ['posts', tagIdSet.join(','), order],
+    ({pageParam = 0}) => getPostsByTag({page: pageParam, tagIdSet, order}),
     {
-      getNextPageParam: lastPage => {
-        return lastPage.nextPage;
-      },
+      getNextPageParam: lastPage => lastPage.number + 1,
     },
   );
 };

--- a/src/querys/useGetPost.ts
+++ b/src/querys/useGetPost.ts
@@ -3,28 +3,8 @@ import {useQuery} from 'react-query';
 import getPost from 'src/apis/getPost';
 import {Post} from 'src/types';
 
-const postInitialData = {
-  id: 0,
-  likeCount: 0,
-  postImageSet: [],
-  status: '',
-  content: '',
-  createdAt: '',
-  updatedAt: '',
-  postTagSet: [],
-  title: '',
-  user: {
-    email: '',
-    status: '',
-    upwd: '',
-    userRole: '',
-  },
-};
-
 const useGetPost = (id: number) => {
-  return useQuery<Post>(['post', id], getPost, {
-    initialData: postInitialData,
-  });
+  return useQuery<Post>(['post', id], getPost);
 };
 
 export default useGetPost;

--- a/src/querys/useGetPosts.ts
+++ b/src/querys/useGetPosts.ts
@@ -1,0 +1,27 @@
+import {AxiosError} from 'axios';
+import {useInfiniteQuery} from 'react-query';
+
+import getPosts from 'src/apis/getPosts';
+import {Post, ServerResponse} from 'src/types';
+
+interface Parameter {
+  order: string;
+  userId?: string;
+}
+
+const useGetPosts = ({order, userId}: Parameter) => {
+  return useInfiniteQuery<
+    ServerResponse<Post>,
+    AxiosError,
+    ServerResponse<Post>,
+    [string, string, string | undefined]
+  >(
+    ['post', order, userId],
+    ({queryKey, pageParam = 0}) => getPosts({order: queryKey[1], page: pageParam, userId}),
+    {
+      getNextPageParam: lastPage => lastPage.number + 1,
+    },
+  );
+};
+
+export default useGetPosts;

--- a/src/querys/useGetPostsByTag.ts
+++ b/src/querys/useGetPostsByTag.ts
@@ -7,7 +7,7 @@ import {Post, ServerResponse} from 'src/types';
 const useGetPostsByTag = (tagIdSet: number[]) => {
   return useQuery<ServerResponse<Post>, AxiosError, ServerResponse<Post>, [string, number[]]>(
     ['post', tagIdSet],
-    ({queryKey}) => getPostsByTag(queryKey[1]),
+    ({queryKey}) => getPostsByTag({tagIdSet: queryKey[1], order: 'popular'}),
   );
 };
 

--- a/src/querys/useGetPostsByUserId.ts
+++ b/src/querys/useGetPostsByUserId.ts
@@ -1,0 +1,27 @@
+import {AxiosError} from 'axios';
+import {useInfiniteQuery} from 'react-query';
+
+import getPosts from 'src/apis/getPosts';
+import {Post, ServerResponse} from 'src/types';
+
+interface Parameter {
+  order: string;
+  userId?: string;
+}
+
+const useGetPostsByUserId = ({order, userId}: Parameter) => {
+  return useInfiniteQuery<
+    ServerResponse<Post>,
+    AxiosError,
+    ServerResponse<Post>,
+    [string, string, string | undefined]
+  >(
+    ['post', order, userId],
+    ({queryKey, pageParam = 0}) => getPosts({order: queryKey[1], page: pageParam, userId}),
+    {
+      getNextPageParam: lastPage => lastPage.number + 1,
+    },
+  );
+};
+
+export default useGetPostsByUserId;

--- a/src/querys/useGetUserLike.ts
+++ b/src/querys/useGetUserLike.ts
@@ -1,0 +1,11 @@
+import {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+
+import getUserLike from 'src/apis/getUserLike';
+import {UserLike} from 'src/types';
+
+const useGetUserLike = () => {
+  return useQuery<UserLike, AxiosError, UserLike, [string]>(['userLike'], getUserLike);
+};
+
+export default useGetUserLike;

--- a/src/querys/useGetUserLikeBooth.ts
+++ b/src/querys/useGetUserLikeBooth.ts
@@ -1,0 +1,14 @@
+import {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+
+import getUserLikeBooth from 'src/apis/getUserLikeBooth';
+import {UserLikeBooth} from 'src/types';
+
+const useGetUserLikeBooth = () => {
+  return useQuery<UserLikeBooth[], AxiosError, UserLikeBooth[], [string]>(
+    ['userLikeBooth'],
+    getUserLikeBooth,
+  );
+};
+
+export default useGetUserLikeBooth;

--- a/src/querys/useGetUserLikeImage.ts
+++ b/src/querys/useGetUserLikeImage.ts
@@ -1,0 +1,14 @@
+import {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+
+import getUserLikeImage from 'src/apis/getUserLikeImage';
+import {UserLikeImage} from 'src/types';
+
+const useGetUserLikeImage = () => {
+  return useQuery<UserLikeImage[], AxiosError, UserLikeImage[], [string]>(
+    ['userLikeImage'],
+    getUserLikeImage,
+  );
+};
+
+export default useGetUserLikeImage;

--- a/src/querys/useGetUserList.ts
+++ b/src/querys/useGetUserList.ts
@@ -1,9 +1,11 @@
+import {AxiosError} from 'axios';
 import {useQuery} from 'react-query';
 
 import getUserList from 'src/apis/getUserList';
+import {UserList} from 'src/types';
 
 const useGetUserList = () => {
-  return useQuery(['userList'], getUserList);
+  return useQuery<UserList, AxiosError, UserList, [string]>(['userList'], getUserList);
 };
 
 export default useGetUserList;

--- a/src/querys/useMutatePostLike.ts
+++ b/src/querys/useMutatePostLike.ts
@@ -1,0 +1,9 @@
+import {useMutation} from 'react-query';
+
+import mutatePostLike from 'src/apis/mutatePostLike';
+
+const useMutatePostLike = () => {
+  return useMutation((id: number) => mutatePostLike(id));
+};
+
+export default useMutatePostLike;

--- a/src/querys/useMutateReviewImageLike.ts
+++ b/src/querys/useMutateReviewImageLike.ts
@@ -1,0 +1,9 @@
+import {useMutation} from 'react-query';
+
+import mutatePostLike from 'src/apis/mutatePostLike';
+
+const useMutateReviewImageLike = () => {
+  return useMutation((id: number) => mutatePostLike(id));
+};
+
+export default useMutateReviewImageLike;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -19,6 +19,7 @@ export interface Post {
   postTagSet: PostTag[];
   postImageSet: PostImage[];
   user: User;
+  like: boolean;
 }
 
 export interface Recommendation {
@@ -189,4 +190,9 @@ export interface UserLikeBooth {
   imageUrl: string;
   createdAt: string;
   like: true;
+}
+
+export interface UserList {
+  reviewList: Review[];
+  postList: Post[];
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -161,3 +161,32 @@ export interface FormImage {
   type: string;
   name: string | undefined;
 }
+
+export interface UserLike {
+  imageList: UserLikeImage[];
+  photoBoothList: UserLikeBooth[];
+}
+
+export interface UserLikeImage {
+  id: 3;
+  type: 'REVIEW' | 'POST';
+  imageUrl: string;
+  createdAt: string;
+  like: true;
+}
+
+export interface UserLikeBooth {
+  id: number;
+  name: string;
+  jibunAddress: string;
+  roadAddress: string;
+  latitude: number;
+  longitude: number;
+  likeCount: number;
+  reviewCount: number;
+  starScore: number;
+  status: string;
+  imageUrl: string;
+  createdAt: string;
+  like: true;
+}


### PR DESCRIPTION
## Summary

- FeedCard 의 좋아요 버튼 클릭 시 active 값이 수정되도록 구현
- SixCard 컴포넌트는 부스 리뷰가 아닌 포스트 기능에만 사용되는 것을 확인했기 때문에, 포스트 데이터에 대한 처리만 되도록 구현함.
- 추천에서 좋아요를 누르고 찜 목록으로 이동하면, 좋아요 누른 아이템을 바로 확인할 수 있음
- 찜 목록에서 Active 된 좋아요 버튼을 누르면 찜 목록에서 바로 삭제됨 (이 부분은 디자이너랑 얘기를 해서 구체적인 플로우를 정해야 할 듯)
- axios 인터셉터에서 accessToken이 수정되면 인터셉터 설정이 수정되도록 수정함. (useEffect의 deps로 accessToken 삽입)

## Comments

- 다음 작업은 포스트 리스트 상세 좋아요 구현입니다.