### PR TITLE
[#175] Filter Sheet 변경된 디자인 반영 및 최적화

### DIFF
--- a/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
+++ b/src/components/PostListDetail/CardListOrganism/CardListOrganism.tsx
@@ -18,9 +18,14 @@ const CardListOrganism = () => {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const {tagIdSet} = useFilteredItem();
-  const {order} = useSelector((state: RootState) => state.postReducer);
+  const {order, isOpenFilterSheet} = useSelector((state: RootState) => state.postReducer);
   const {userInfo} = useSelector((state: RootState) => state.userReducer);
-  const {data, fetchNextPage} = useGetInfinitePosts({tagIdSet, order});
+  const {data, fetchNextPage} = useGetInfinitePosts(
+    {tagIdSet, order},
+    {
+      enabled: !isOpenFilterSheet,
+    },
+  );
   const {mutate: likePost} = useMutatePostLike();
   const posts = data?.pages.flatMap(({content}) => content);
 

--- a/src/components/PostListDetail/FilterPages/BrandFilter/BrandFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/BrandFilter/BrandFilter.tsx
@@ -24,14 +24,9 @@ const BrandFilter = () => {
 
   return (
     <Container>
-      {(tags[0] || []).map(({id, title, postCount}) => (
+      {(tags[0] || []).map(({id, title}) => (
         <ChipWrapper key={id}>
-          <FilterChip
-            title={title}
-            count={postCount}
-            selected={filteredItems[id]}
-            onPress={handlePressChip(id)}
-          />
+          <FilterChip title={title} selected={filteredItems[id]} onPress={handlePressChip(id)} />
         </ChipWrapper>
       ))}
     </Container>

--- a/src/components/PostListDetail/FilterPages/FrameFilter/FrameFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/FrameFilter/FrameFilter.tsx
@@ -24,14 +24,9 @@ const FrameFilter = () => {
 
   return (
     <Container>
-      {(tags[0] || []).map(({id, title, postCount}) => (
+      {(tags[0] || []).map(({id, title}) => (
         <ChipWrapper key={id}>
-          <FilterChip
-            title={title}
-            count={postCount}
-            selected={filteredItems[id]}
-            onPress={handlePressChip(id)}
-          />
+          <FilterChip title={title} selected={filteredItems[id]} onPress={handlePressChip(id)} />
         </ChipWrapper>
       ))}
     </Container>

--- a/src/components/PostListDetail/FilterPages/HeadcountFilter/HeadcountFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/HeadcountFilter/HeadcountFilter.tsx
@@ -32,14 +32,9 @@ const HeadcountFilter = () => {
   return (
     <Container>
       <NestedFilterOrganism type="인원 수">
-        {(tags[0] || []).map(({id, title, postCount}) => (
+        {(tags[0] || []).map(({id, title}) => (
           <ChipWrapper key={id}>
-            <FilterChip
-              title={title}
-              count={postCount}
-              selected={number[id]}
-              onPress={handlePressNumberChip(id)}
-            />
+            <FilterChip title={title} selected={number[id]} onPress={handlePressNumberChip(id)} />
           </ChipWrapper>
         ))}
       </NestedFilterOrganism>

--- a/src/components/PostListDetail/FilterPages/PoseFilter/PoseFilter.tsx
+++ b/src/components/PostListDetail/FilterPages/PoseFilter/PoseFilter.tsx
@@ -29,23 +29,17 @@ const PoseFilter = () => {
   return (
     <Container>
       <NestedFilterOrganism type="감정">
-        {(tags[0] || []).map(({id, title, postCount}) => (
+        {(tags[0] || []).map(({id, title}) => (
           <ChipWrapper key={id}>
-            <FilterChip
-              title={title}
-              count={postCount}
-              selected={emotion[id]}
-              onPress={handlePressEmotionChip(id)}
-            />
+            <FilterChip title={title} selected={emotion[id]} onPress={handlePressEmotionChip(id)} />
           </ChipWrapper>
         ))}
       </NestedFilterOrganism>
       <NestedFilterOrganism type="상황">
-        {(tags[1] || []).map(({id, title, postCount}) => (
+        {(tags[1] || []).map(({id, title}) => (
           <ChipWrapper key={id}>
             <FilterChip
               title={title}
-              count={postCount}
               selected={situation[id]}
               onPress={handlePressSituationChip(id)}
             />

--- a/src/components/PostListDetail/FilterSheetBackdrop/FilterSheetBackdrop.tsx
+++ b/src/components/PostListDetail/FilterSheetBackdrop/FilterSheetBackdrop.tsx
@@ -8,6 +8,7 @@ import FilterOrganism from '../FilterOrganism';
 import {Blocking, HeaderContainer, HeaderTitle, TitleContainer} from './FilterSheetBackdrop.styles';
 
 import LeftBackHeader from 'src/components/utils/Header/LeftBackHeader';
+import {FILTER} from 'src/constants/filters';
 import {clearFilter, closeFilterSheet} from 'src/redux/actions/PostAction';
 import {setCustomTagKeyword} from 'src/redux/actions/RecommendAction';
 import {RootState} from 'src/redux/store';
@@ -23,14 +24,14 @@ const FilterSheetBackdrop = ({title}: {title?: string}) => {
     dispatch(closeFilterSheet());
   };
   const handleLeftBackHeader = () => {
-    dispatch(clearFilter(4));
+    dispatch(clearFilter());
     navigation.navigate('Recommend' as never);
   };
   const handleTitleContainer = () => {
     if (title) {
       dispatch(setCustomTagKeyword(title));
     }
-    dispatch(clearFilter(4));
+    dispatch(clearFilter(FILTER.CUSTOM));
     navigation.goBack();
   };
 

--- a/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
+++ b/src/components/PostListDetail/FilterSheetFooter/FilterSheetFooter.tsx
@@ -5,15 +5,11 @@ import {Container, RefreshWrapper} from './FilterSheetFooter.styles';
 
 import {PressableRefreshIcon} from 'src/components/utils/Pressables/PressableIcons';
 import PressableSubmit from 'src/components/utils/Pressables/PressableSubmit';
-import useFilteredItem from 'src/hooks/useFilteredItem';
-import useGetPostsByTag from 'src/querys/useGetPostsByTag';
 import {clearFilter, closeFilterSheet} from 'src/redux/actions/PostAction';
 import {widthPercentage} from 'src/styles/ScreenResponse';
 
 const FilterSheetFooter = () => {
   const dispatch = useDispatch();
-  const {tagIdSet} = useFilteredItem();
-  const {data} = useGetPostsByTag(tagIdSet);
 
   const handlePressRefresh = () => {
     dispatch(clearFilter());
@@ -29,7 +25,7 @@ const FilterSheetFooter = () => {
         <PressableRefreshIcon onPress={handlePressRefresh} />
       </RefreshWrapper>
       <PressableSubmit style={{width: widthPercentage(286)}} onPress={handleSubmit}>
-        {data === undefined ? '' : `${data.content.length}개 결과보기`}
+        결과보기
       </PressableSubmit>
     </Container>
   );

--- a/src/components/Recommend/FeedCard/RecommendFeedCard.tsx
+++ b/src/components/Recommend/FeedCard/RecommendFeedCard.tsx
@@ -1,3 +1,4 @@
+import {useNavigation} from '@react-navigation/native';
 import React from 'react';
 import {PressableProps} from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -17,9 +18,11 @@ interface Props extends PressableProps {
 }
 
 const RecommendFeedCard = ({imgUrl, onLike, isLike, isMine, ...props}: Props) => {
+  const navigation = useNavigation();
   const data = useSelector((state: RootState) => state.userReducer);
   const handleLike = () => {
     if (!data.isLoggedIn) {
+      navigation.navigate('RouteLoginScreen' as never);
       return;
     }
     onLike();

--- a/src/components/utils/TabBar/TabBar.tsx
+++ b/src/components/utils/TabBar/TabBar.tsx
@@ -79,7 +79,7 @@ const TabBar = ({descriptors, state, navigation}: BottomTabBarProps) => {
 
   return (
     <SafeAreaView>
-      <Animated.View style={{height: slideUpAnimation, flexDirection: 'row'}}>
+      <Animated.View style={{height: slideUpAnimation, flexDirection: 'row', overflow: 'hidden'}}>
         {state.routes.map((route, index) => {
           const {options} = descriptors[route.key];
           const label = options.tabBarLabel as string;

--- a/src/querys/useGetInfinitePosts.ts
+++ b/src/querys/useGetInfinitePosts.ts
@@ -1,5 +1,5 @@
 import {AxiosError} from 'axios';
-import {useInfiniteQuery} from 'react-query';
+import {QueryKey, useInfiniteQuery, UseInfiniteQueryOptions} from 'react-query';
 
 import getPostsByTag from 'src/apis/getPostsByTag';
 import {Post, ServerResponse} from 'src/types';
@@ -11,19 +11,26 @@ interface Parameter {
   order: string;
 }
 
-const useGetInfinitePosts = ({tagIdSet, order}: Parameter) => {
-  return useInfiniteQuery<
-    ServerResponse<Post>,
-    AxiosError,
-    ServerResponse<Post>,
-    [string, string, string]
-  >(
+const useGetInfinitePosts = (
+  {tagIdSet, order}: Parameter,
+  options?: Omit<
+    UseInfiniteQueryOptions<
+      ServerResponse<Post>,
+      AxiosError<unknown, any>,
+      ServerResponse<Post>,
+      ServerResponse<Post>
+    >,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  return useInfiniteQuery<ServerResponse<Post>, AxiosError, ServerResponse<Post>, QueryKey>(
     ['post', tagIdSet.join(','), order],
     ({pageParam = 0}) => {
       return getPostsByTag({page: pageParam, tagIdSet, order});
     },
     {
       getNextPageParam: lastPage => lastPage.number + 1,
+      ...options,
     },
   );
 };

--- a/src/querys/useGetTagForm.ts
+++ b/src/querys/useGetTagForm.ts
@@ -8,6 +8,7 @@ const useGetTagForm = (tagType: number) => {
   return useQuery<Promise<Tag[][]>, AxiosError, Promise<Tag[][]>, [string, number]>(
     ['tag', tagType],
     ({queryKey}) => getTagForm(queryKey[1]),
+    {staleTime: Infinity},
   );
 };
 

--- a/src/screens/RecommendScreen/PostListDetailScreen.header.tsx
+++ b/src/screens/RecommendScreen/PostListDetailScreen.header.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import React from 'react';
+import {useDispatch} from 'react-redux';
 
 import {PostListDetailScreenProps} from './PostListDetailScreen';
 
@@ -9,6 +10,7 @@ import {
   PressableSearchIcon,
 } from 'src/components/utils/Pressables/PressableIcons';
 import {SubHeadline2} from 'src/components/utils/Text';
+import {clearFilter} from 'src/redux/actions/PostAction';
 import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
 import theme from 'src/styles/Theme';
 
@@ -34,12 +36,18 @@ const BackButtonWrapper = styled.View({position: 'absolute', left: widthPercenta
 const SearchButtonWrapper = styled.View({position: 'absolute', right: widthPercentage(16)});
 
 export const Header = () => {
+  const dispatch = useDispatch();
   const navigation = useNavigation();
 
   return (
     <Container>
       <BackButtonWrapper>
-        <PressableLeftArrowIcon onPress={() => navigation.goBack()} />
+        <PressableLeftArrowIcon
+          onPress={() => {
+            navigation.goBack();
+            dispatch(clearFilter());
+          }}
+        />
       </BackButtonWrapper>
       <ScreenTitle>포스트</ScreenTitle>
       <SearchButtonWrapper>


### PR DESCRIPTION
## Summary

- CTA 버튼에 post 총 개수를 없앰. FIlter Chip에도 마찬가지로 count를 없앰.
- Filter Sheet가 올라가있는 상황에서는 절대 포스트를 불러오는 API요청이 발생하지 않도록 막음.
- Filter Sheet의 태그들을 앱 사용 시에 단 한번만 요청해서 그 값을 재사용하도록 최적화 함.
- PostList 스크린에서 뒤로가기 버튼 클릭 시 선택된 필터들이 clear 되도록 수정.
- 로그인하지 않은 상태에서 FeedCard의 좋아요 버튼 클릭 시, 로그인 스크린으로 이동되도록 구현.

## Comments

- useQuery의 enable option에 isOpenFilterSheet를 주어, 필터 시트가 올라가있는 상황에서 refetch 되는 것을 막았습니다.
- 필터 태그를 얻어오는 useQuery의 staleTime에 Infinity를 주어, 앱 시작 시 단 한번만 요청하여 재사용하는 로직으로 수정했습니다.