### PR TITLE
[#241] 세부 버그 hotfix

### DIFF
--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -3,7 +3,7 @@ import {GoogleSignin} from '@react-native-google-signin/google-signin';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {useNavigation} from '@react-navigation/native';
 import React, {useEffect} from 'react';
-import Config from 'react-native-config';
+import {Config} from 'react-native-config';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import SplashScreen from 'react-native-splash-screen';
 import {useDispatch, useSelector} from 'react-redux';
@@ -23,9 +23,7 @@ const Tab = createBottomTabNavigator();
 const AppInner = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const {accessToken: newToken, isSettingInterceptor} = useSelector(
-    (state: RootState) => state.userReducer,
-  );
+  const {isSettingInterceptor} = useSelector((state: RootState) => state.userReducer);
 
   useEffect(() => {
     GoogleSignin.configure({
@@ -55,9 +53,6 @@ const AppInner = () => {
   }, []);
 
   useEffect(() => {
-    if (!newToken) {
-      return;
-    }
     if (!isSettingInterceptor) {
       return;
     }
@@ -67,7 +62,7 @@ const AppInner = () => {
       SplashScreen.hide();
     };
     getUserData();
-  }, [newToken, isSettingInterceptor]);
+  }, [isSettingInterceptor]);
 
   return (
     <Tab.Navigator screenOptions={{headerShown: false}} tabBar={props => <TabBar {...props} />}>

--- a/ios/hot6.xcodeproj/project.pbxproj
+++ b/ios/hot6.xcodeproj/project.pbxproj
@@ -516,6 +516,13 @@
 			remoteGlobalIDString = 3501832F51E21BCD681DC315B3424B43;
 			remoteInfo = BVLinearGradient;
 		};
+		0678B6BF28B7CA3D00EDE673 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 06305250287C4EC600DDFD03 /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 69C867BDBFC84471D95920DC6B2EF5C5;
+			remoteInfo = RNAppleAuthentication;
+		};
 		068EC0CC28B2EE3C004D239F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 06305250287C4EC600DDFD03 /* Pods.xcodeproj */;
@@ -523,12 +530,6 @@
 			remoteGlobalIDString = F6B923B5A106791D9D52196A67E572B3;
 			remoteInfo = "react-native-splash-screen";
 		};
-		06ACA34328B757CD00F41303 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 06305250287C4EC600DDFD03 /* Pods.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 69C867BDBFC84471D95920DC6B2EF5C5;
-			remoteInfo = RNAppleAuthentication;
 		069CBE7B28B68D2400A2D44D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 06305250287C4EC600DDFD03 /* Pods.xcodeproj */;
@@ -658,7 +659,7 @@
 		0630524D287C4EB900DDFD03 /* hot6-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "hot6-Bridging-Header.h"; sourceTree = "<group>"; };
 		0630524E287C4EB900DDFD03 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		06305250287C4EC600DDFD03 /* Pods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Pods.xcodeproj; sourceTree = "<group>"; };
-		06ACA2DF28B755DE00F41303 /* hot6.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = hot6.entitlements; path = hot6/hot6.entitlements; sourceTree = "<group>"; };
+		0678B6C128B7CA4700EDE673 /* hot6.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = hot6.entitlements; path = hot6/hot6.entitlements; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* hot6.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = hot6.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = hot6/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = hot6/AppDelegate.mm; sourceTree = "<group>"; };
@@ -787,7 +788,7 @@
 				063052D3287C4EC600DDFD03 /* React-RCTText */,
 				063052D5287C4EC600DDFD03 /* React-RCTVibration */,
 				063052D7287C4EC600DDFD03 /* ReactCommon */,
-				06ACA34428B757CD00F41303 /* RNAppleAuthentication */,
+				0678B6C028B7CA3D00EDE673 /* RNAppleAuthentication */,
 				065C89A028B3B4E80039707C /* RNCAsyncStorage */,
 				062EA27E288ED9D00043B3EC /* RNFastImage */,
 				06C92A5828996D04009267C3 /* RNGestureHandler */,
@@ -813,7 +814,7 @@
 		13B07FAE1A68108700A75B9A /* hot6 */ = {
 			isa = PBXGroup;
 			children = (
-				06ACA2DF28B755DE00F41303 /* hot6.entitlements */,
+				0678B6C128B7CA4700EDE673 /* hot6.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -1531,6 +1532,14 @@
 			remoteRef = 066C199728A27BDA006E14DB /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		0678B6C028B7CA3D00EDE673 /* RNAppleAuthentication */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			name = RNAppleAuthentication;
+			path = libRNAppleAuthentication.a;
+			remoteRef = 0678B6BF28B7CA3D00EDE673 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		068EC0CD28B2EE3C004D239F /* react-native-splash-screen */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1539,12 +1548,6 @@
 			remoteRef = 068EC0CC28B2EE3C004D239F /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		06ACA34428B757CD00F41303 /* RNAppleAuthentication */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			name = RNAppleAuthentication;
-			path = libRNAppleAuthentication.a;
-			remoteRef = 06ACA34328B757CD00F41303 /* PBXContainerItemProxy */;
 		069CBE7C28B68D2400A2D44D /* Base64 */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -2009,8 +2012,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = hot6/hot6.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = F34T4G7PLC;
+				DEVELOPMENT_TEAM = B7925JYQ6U;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = hot6/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2147,7 +2151,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2221,7 +2225,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/src/apis/appleLoginBridge.ts
+++ b/src/apis/appleLoginBridge.ts
@@ -2,7 +2,7 @@ import {appleAuth} from '@invertase/react-native-apple-authentication';
 import {Alert} from 'react-native';
 
 interface LoginParam {
-  email: string | null;
+  email?: string | null;
   providerId: string;
   provider: 'KAKAO' | 'GOOGLE' | 'APPLE';
 }
@@ -13,13 +13,18 @@ const appleLoginBridge = async (): Promise<LoginParam> => {
       requestedOperation: appleAuth.Operation.LOGIN,
       requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME],
     });
-    console.log(appleAuthRequestResponse.user, appleAuthRequestResponse.email);
-
-    return {
-      email: appleAuthRequestResponse.email,
-      providerId: appleAuthRequestResponse.user,
-      provider: 'APPLE',
-    };
+    if (appleAuthRequestResponse.email) {
+      return {
+        email: appleAuthRequestResponse.email,
+        providerId: appleAuthRequestResponse.user,
+        provider: 'APPLE',
+      };
+    } else {
+      return {
+        providerId: appleAuthRequestResponse.user,
+        provider: 'APPLE',
+      };
+    }
   } catch (error: any) {
     Alert.alert('로그인 도중 오류가 발생하였습니다.');
     return Promise.reject(error);

--- a/src/apis/getUserList.ts
+++ b/src/apis/getUserList.ts
@@ -8,6 +8,7 @@ const getUserList = async () => {
     }
     return result.data;
   } catch (error) {
+    console.log(error);
     return Promise.reject(error);
   }
 };

--- a/src/apis/getUserList.ts
+++ b/src/apis/getUserList.ts
@@ -8,7 +8,6 @@ const getUserList = async () => {
     }
     return result.data;
   } catch (error) {
-    console.log(error);
     return Promise.reject(error);
   }
 };

--- a/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
+++ b/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
@@ -102,7 +102,7 @@ const ReviewImageOrganism = () => {
         ),
       );
     };
-    const images = await await takeResizeImages(response);
+    const images = await takeResizeImages(response);
 
     dispatch(
       changeDeleteImage(imageData.filter((image: any) => !!image.id).map((image: any) => image.id)),

--- a/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
+++ b/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
@@ -102,7 +102,8 @@ const ReviewImageOrganism = () => {
         ),
       );
     };
-    const images = await takeResizeImages(response);
+    const images = await await takeResizeImages(response);
+
     dispatch(
       changeDeleteImage(imageData.filter((image: any) => !!image.id).map((image: any) => image.id)),
     );

--- a/src/components/PostWrite/AddPhotoOrganism/AddPhotoOrganism.tsx
+++ b/src/components/PostWrite/AddPhotoOrganism/AddPhotoOrganism.tsx
@@ -39,12 +39,16 @@ const AddPhotoOrganism = () => {
       imageResponse.splice(0, 1).map(item =>
         ImageResizer.createResizedImage(
           item.path,
-          600,
-          600,
+          1000,
+          1000,
           item.mime.includes('jpeg') ? 'JPEG' : 'PNG',
           100,
           0,
         ).then(r => {
+          if (r.size > 3000000) {
+            Alert.alert('사진 용량이 너무 큽니다.');
+            return;
+          }
           dispatch(addPostWriteImage({uri: r.uri, name: r.name, type: item.mime}));
         }),
       );

--- a/src/components/SearchTagInput/TagSearchList/TagSearchList.styles.tsx
+++ b/src/components/SearchTagInput/TagSearchList/TagSearchList.styles.tsx
@@ -7,6 +7,7 @@ import theme from 'src/styles/Theme';
 export const SearchListView = styled.View({
   alignSelf: 'center',
   width: '100%',
+  height: heightPercentage(515),
 });
 
 export const TextView = styled.View({

--- a/src/components/utils/DismissCommonKeyboardView/DismissCommonKeyboardView.tsx
+++ b/src/components/utils/DismissCommonKeyboardView/DismissCommonKeyboardView.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {TouchableWithoutFeedback, Keyboard} from 'react-native';
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
+
+const DismissCommonKeyboardView = ({children, ...props}: any) => (
+  <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+    <KeyboardAwareScrollView
+      {...props}
+      style={props.style}
+      bounces={false}
+      enabled
+      keyboardVerticalOffset={200}
+      nestedScrollEnabled
+      contentContainerStyle={{flexGrow: 1}}
+      scrollEnabled={false}>
+      {children}
+    </KeyboardAwareScrollView>
+  </TouchableWithoutFeedback>
+);
+
+export default DismissCommonKeyboardView;

--- a/src/components/utils/DismissCommonKeyboardView/index.tsx
+++ b/src/components/utils/DismissCommonKeyboardView/index.tsx
@@ -1,0 +1,3 @@
+import DismissCommonKeyboardView from './DismissCommonKeyboardView';
+
+export default DismissCommonKeyboardView;

--- a/src/querys/useGetUserList.ts
+++ b/src/querys/useGetUserList.ts
@@ -1,11 +1,17 @@
 import {AxiosError} from 'axios';
 import {useQuery} from 'react-query';
+import {useSelector} from 'react-redux';
 
 import getUserList from 'src/apis/getUserList';
+import {RootState} from 'src/redux/store';
 import {UserList} from 'src/types';
 
 const useGetUserList = () => {
-  return useQuery<UserList, AxiosError, UserList, [string]>(['userList'], getUserList);
+  const {userInfo} = useSelector((state: RootState) => state.userReducer);
+  const userInfoValid = Object.keys(userInfo).length !== 0;
+  return useQuery<UserList, AxiosError, UserList, [string]>(['userList'], getUserList, {
+    enabled: userInfoValid,
+  });
 };
 
 export default useGetUserList;

--- a/src/screens/BoothScreen/PostReviewScreen/BoothTagInputScreen.tsx
+++ b/src/screens/BoothScreen/PostReviewScreen/BoothTagInputScreen.tsx
@@ -5,7 +5,7 @@ import {PostReviewParamList} from '.';
 
 import BoothReviewHeader from 'src/components/BoothReview/BoothReviewHeader';
 import ReviewTagOrganism from 'src/components/BoothReview/ReviewTagOrganism';
-import DismissKeyboardView from 'src/components/utils/DismissKeyboardScrollView';
+import DismissCommonKeyboardView from 'src/components/utils/DismissCommonKeyboardView';
 
 export type BoothTagInputScreenProps = NativeStackScreenProps<
   PostReviewParamList,
@@ -13,10 +13,10 @@ export type BoothTagInputScreenProps = NativeStackScreenProps<
 >;
 const BoothTagInputScreen = ({navigation}: BoothTagInputScreenProps) => {
   return (
-    <DismissKeyboardView>
+    <DismissCommonKeyboardView>
       <BoothReviewHeader onPress={() => navigation.goBack()}>부스 리뷰 작성</BoothReviewHeader>
       <ReviewTagOrganism />
-    </DismissKeyboardView>
+    </DismissCommonKeyboardView>
   );
 };
 

--- a/src/screens/RecommendScreen/PostWriteScreen/CustomTagScreen.tsx
+++ b/src/screens/RecommendScreen/PostWriteScreen/CustomTagScreen.tsx
@@ -6,7 +6,7 @@ import {useDispatch} from 'react-redux';
 import {PostWriteParamList} from '.';
 
 import InputCustomTagOrganism from 'src/components/PostWrite/InputCustomTagOrganism/InputCustomTagOrganism';
-import DismissKeyboardView from 'src/components/utils/DismissKeyboardScrollView';
+import DismissCommonKeyboardView from 'src/components/utils/DismissCommonKeyboardView';
 import LeftBackHeader from 'src/components/utils/Header/LeftBackHeader';
 import useFocus from 'src/hooks/useFocus';
 import {changeModifyMode, changeScreen} from 'src/redux/actions/PostWriteAction';
@@ -32,11 +32,11 @@ const CustomTagScreen = ({navigation, route}: CustomTagScreenProps) => {
 
   return (
     <SafeAreaView>
-      <DismissKeyboardView>
+      <DismissCommonKeyboardView>
         <LeftBackHeader onPressBack={() => navigation.goBack()}>태그 직접 입력</LeftBackHeader>
         <InputCustomTagOrganism />
         <View style={{height: heightPercentage(300)}} />
-      </DismissKeyboardView>
+      </DismissCommonKeyboardView>
     </SafeAreaView>
   );
 };

--- a/src/screens/RecommendScreen/RecommendDetailScreen.header.tsx
+++ b/src/screens/RecommendScreen/RecommendDetailScreen.header.tsx
@@ -16,19 +16,24 @@ interface Props {
   navigation: NativeStackNavigationProp<RecommendParamList, 'RecommendDetail', undefined>;
   postId: number;
   isRecord?: boolean;
+  isStorage?: boolean;
 }
 
-const RecommendDetailScreenHeader = ({navigation, postId, isRecord}: Props) => {
+const RecommendDetailScreenHeader = ({navigation, postId, isRecord, isStorage}: Props) => {
   const queryClient = useQueryClient();
   const dispatch = useDispatch();
   const {userInfo} = useSelector((state: RootState) => state.userReducer);
   const {data} = useGetPost(postId);
   const {mutate: deletePost} = useDeletePost();
-
   const goBack = () => {
     if (isRecord) {
       navigation.reset({
         routes: [{name: 'RouteRecordScreen' as never}],
+        index: 0,
+      });
+    } else if (isStorage) {
+      navigation.reset({
+        routes: [{name: 'StorageScreen' as never}],
         index: 0,
       });
     } else {

--- a/src/screens/RecommendScreen/RecommendDetailScreen.tsx
+++ b/src/screens/RecommendScreen/RecommendDetailScreen.tsx
@@ -21,6 +21,7 @@ const RecommendDetailScreen = ({navigation, route}: DetailScreenProps) => {
         navigation={navigation}
         postId={route.params.postId}
         isRecord={route.params.isRecord}
+        isStorage={route.params.isStorage}
       />
       <ScrollView style={{height: Dimensions.get('window').height - heightPercentage(125)}}>
         <RecommendDetailMainFrame id={route.params.postId} />

--- a/src/screens/RecommendScreen/index.tsx
+++ b/src/screens/RecommendScreen/index.tsx
@@ -12,7 +12,7 @@ const Stack = createNativeStackNavigator();
 
 export type RecommendParamList = {
   RecommendScreen: undefined;
-  RecommendDetail: {postId: number; isRecord?: boolean};
+  RecommendDetail: {postId: number; isRecord?: boolean; isStorage?: boolean};
   PostListDetail: undefined;
   DiffUserPost: {userId: number; username: string};
   RoutePostWrite: {isModifyMode?: boolean};


### PR DESCRIPTION
## Summary
- 찜페이지에서 페이지 여러번 이동시 go Back 되지 않는 문제 해결
- 커스텀 태그 등록 페이지에서 DismissKeyboardScrollView로 생기는 Visualization errror 해결
- 애플로그인 500 에러 수정
- 기록 페이지에서 403 에러 수정
- 앱 로그인 시 AppInner에서 생기는 403 에러 수정
-  사진 용량 3 mb 넘으면 Alert 추가
-  커스텀 태그 창 FlatList 스크롤 안되는 문제 해결

## Comments
- 2번째 문제와 7번째 문제를 고치는데 시간 다박았는데 결론적으론 간단하게 고치기 불가능합니다. 따라서 문제가 발생하지 않게 조치만 해두었습니다. 해당 오류는 두개의 스크롤뷰가 같은 방향을 가리키고 겹쳐있을때 발생하는데 상위 컴포넌트인 DissmissCommonKeyboardView를 새로 제작하여 ScroillView disable 시켰기 때문에 해당 오류를 내뿜기만 하지 실제 동작엔 문제가 아마 없을겁니다. 원래는 [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview)를 사용하여 해결해보려고 했지만, 오히려 문제가 더 생기기만해서 일단 이렇게 구현해두고 다음에 다시 고치는걸로 하는게 좋을거같습니다. (해당 컴포넌트 사용시 TabBar가 작동하는 PostWrite 쪽에 문제가 발생함)