### PR TITLE
[#254] 글 작성 시 1초 뒤에 버튼의 disabled가 풀려 글 작성 요청을 여러 번 보내는 문제 해결

### DIFF
--- a/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
+++ b/src/components/BoothReview/ReviewImageOrganism/ReviewImageOrganism.tsx
@@ -57,13 +57,7 @@ const ReviewImageOrganism = () => {
   const reviewId = useSelector((state: RootState) => state.reviewReducer.reviewId);
   const inputPostReviewData = useSelector((state: RootState) => state.reviewReducer);
   const [disabled, setDisabled] = useState(false);
-  useEffect(() => {
-    if (disabled) {
-      setTimeout(() => {
-        setDisabled(false);
-      }, 1000);
-    }
-  }, [disabled]);
+
   const onChangeFile = useCallback(async () => {
     try {
       await requestcameraPermission();
@@ -163,6 +157,9 @@ const ReviewImageOrganism = () => {
             queryClient.invalidateQueries(['reviews']);
             navigation.navigate('BoothReviewComplete' as never, {} as never);
           },
+          onSettled: () => {
+            setDisabled(false);
+          },
         },
       );
     } else {
@@ -183,6 +180,9 @@ const ReviewImageOrganism = () => {
             queryClient.invalidateQueries(['userList']);
             queryClient.invalidateQueries(['photo-booth', boothId]);
             navigation.navigate('BoothReviewComplete' as never, {} as never);
+          },
+          onSettled: () => {
+            setDisabled(false);
           },
         },
       );

--- a/src/components/utils/TabBar/PostWriteTabBar.tsx
+++ b/src/components/utils/TabBar/PostWriteTabBar.tsx
@@ -1,5 +1,5 @@
 import {useNavigation} from '@react-navigation/native';
-import React, {PropsWithChildren, useEffect, useMemo, useState} from 'react';
+import React, {PropsWithChildren, useMemo, useState} from 'react';
 import {PressableProps} from 'react-native';
 import {useQueryClient} from 'react-query';
 import {useDispatch, useSelector} from 'react-redux';
@@ -36,13 +36,6 @@ const PostWriteTabBar = ({...props}: PropsWithChildren<PressableProps>) => {
   );
   const [disabled, setDisabled] = useState(false);
 
-  useEffect(() => {
-    if (disabled) {
-      setTimeout(() => {
-        setDisabled(false);
-      }, 500);
-    }
-  }, [disabled]);
   const screens = ['PostWriteMain', 'SelectTag', 'CustomTag', 'Summary', 'ExitPostWrite'];
   const handlePressSubmit = () => {
     setDisabled(true);
@@ -72,6 +65,9 @@ const PostWriteTabBar = ({...props}: PropsWithChildren<PressableProps>) => {
               navigation.navigate(screens[screenIndex + 1] as never);
               dispatch(clearPostWrite());
             },
+            onSettled: () => {
+              setDisabled(false);
+            },
           },
         );
         return;
@@ -92,6 +88,9 @@ const PostWriteTabBar = ({...props}: PropsWithChildren<PressableProps>) => {
               dispatch(changeScreen(4));
               navigation.navigate(screens[screenIndex + 1] as never);
               dispatch(clearPostWrite());
+            },
+            onSettled: () => {
+              setDisabled(false);
             },
           },
         );


### PR DESCRIPTION
## Summary

- ReviewImageOrganism, PostWriteTabBar에서 setTimeout에서 disabled를 1초 뒤에 false로 풀어버리는 로직을 수정함.
- onSettled 핸들러 (에러든 성공이든 무조건 요청이 끝나면 실행되는 이벤트) 에 setDisabled(false)를 추가함.