### PR TITLE
[#245] 안드로이드 다크모드 비활성화 및 토큰 로직 수정

### DIFF
--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -11,6 +11,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import getAccessToken from 'src/apis/getAccessToken';
 import getUser from 'src/apis/getUser';
 import TabBar from 'src/components/utils/TabBar';
+import useLogout from 'src/hooks/useLogout';
 import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
 import {RootState} from 'src/redux/store';
 import RouteBoothScreen from 'src/screens/BoothScreen';
@@ -23,6 +24,7 @@ const Tab = createBottomTabNavigator();
 const AppInner = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const logout = useLogout();
   const {isSettingInterceptor} = useSelector((state: RootState) => state.userReducer);
 
   useEffect(() => {
@@ -57,9 +59,16 @@ const AppInner = () => {
       return;
     }
     const getUserData = async () => {
-      const user = await getUser();
-      dispatch(changeUserInfo(user));
-      SplashScreen.hide();
+      try {
+        const user = await getUser();
+        if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
+          logout();
+        }
+        dispatch(changeUserInfo(user));
+        SplashScreen.hide();
+      } catch (error) {
+        SplashScreen.hide();
+      }
     };
     getUserData();
   }, [isSettingInterceptor]);

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,8 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <!-- disable dark mode -->
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
 </resources>

--- a/src/components/Login/LoginOrganism/LoginOrganism.tsx
+++ b/src/components/Login/LoginOrganism/LoginOrganism.tsx
@@ -21,12 +21,14 @@ import getUser from 'src/apis/getUser';
 import googleLoginBridge from 'src/apis/googleLoginBridge';
 import kakaoLoginBridge from 'src/apis/kakaoLoginBridge';
 import login from 'src/apis/login';
+import useLogout from 'src/hooks/useLogout';
 import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
 import {heightPercentage} from 'src/styles/ScreenResponse';
 import valueOfPlatform from 'src/utils/valueOfPlatform';
+
 const LoginOrganism = () => {
   const navigation = useNavigation();
-
+  const logout = useLogout();
   const dispatch = useDispatch();
 
   const handleLogin = (bridge: any) => async () => {
@@ -34,6 +36,9 @@ const LoginOrganism = () => {
     EncryptedStorage.setItem('refreshToken', token.refreshToken);
     dispatch(setAccessToken(token.token));
     const user = await getUser(token.token);
+    if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
+      logout();
+    }
     dispatch(changeUserInfo(user));
     dispatch(loginAction(true));
     navigation.goBack();

--- a/src/components/Record/EditNickNameHeader/EditNickNameHeader.tsx
+++ b/src/components/Record/EditNickNameHeader/EditNickNameHeader.tsx
@@ -12,6 +12,7 @@ import {
 
 import getUser from 'src/apis/getUser';
 import {PressableLeftArrowIcon} from 'src/components/utils/Pressables/PressableIcons';
+import useLogout from 'src/hooks/useLogout';
 import usePatchNickName from 'src/querys/usePatchNickName';
 import {changeUserInfo} from 'src/redux/actions/UserAction';
 
@@ -25,10 +26,14 @@ const EditNickNameHeader = ({children, onPressBack, isSuccess, name}: PropsWithC
   const {mutate} = usePatchNickName();
   const navigation = useNavigation();
   const dispatch = useDispatch();
+  const logout = useLogout();
   const onPressSuccess = () => {
     mutate(name, {
       onSuccess: async () => {
         const user = await getUser();
+        if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
+          logout();
+        }
         dispatch(changeUserInfo(user));
         navigation.goBack();
       },

--- a/src/components/Setting/SettingOrganism/SettingOrganism.tsx
+++ b/src/components/Setting/SettingOrganism/SettingOrganism.tsx
@@ -1,11 +1,7 @@
-import {GoogleSignin} from '@react-native-google-signin/google-signin';
-import {logout} from '@react-native-seoul/kakao-login';
 import {useNavigation} from '@react-navigation/native';
 import React from 'react';
 import {Alert, SafeAreaView} from 'react-native';
-import EncryptedStorage from 'react-native-encrypted-storage/';
-import {useQueryClient} from 'react-query';
-import {useDispatch, useSelector} from 'react-redux';
+import {useSelector} from 'react-redux';
 
 import {
   Container,
@@ -16,30 +12,18 @@ import {
 } from './SettingOrganism.styles';
 
 import LeftBackHeader from 'src/components/utils/Header/LeftBackHeader';
+import useLogout from 'src/hooks/useLogout';
 import useDeleteUser from 'src/querys/useDeleteUser';
-import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
 import {RootState} from 'src/redux/store';
 const SettingOrganism = () => {
   const isLoggedIn = useSelector((state: RootState) => state.userReducer.isLoggedIn);
   const userInfo = useSelector((state: RootState) => state.userReducer.userInfo);
-  const queryClient = useQueryClient();
   const {mutate} = useDeleteUser();
+  const logout = useLogout();
 
   const navigation = useNavigation();
-  const dispatch = useDispatch();
   const handleLogOut = async () => {
-    const provider = userInfo?.provider;
-    if (provider === 'GOOGLE') {
-      await GoogleSignin.signOut();
-    } else if (provider === 'KAKAO') {
-      await logout();
-    } else if (provider === 'APPLE') {
-    }
-    await EncryptedStorage.removeItem('refreshToken');
-    dispatch(setAccessToken(''));
-    dispatch(changeUserInfo({}));
-    dispatch(loginAction(false));
-    queryClient.invalidateQueries();
+    logout();
     navigation.goBack();
   };
 

--- a/src/components/utils/Interceptor/index.tsx
+++ b/src/components/utils/Interceptor/index.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import React, {PropsWithChildren, useEffect} from 'react';
+import {Alert} from 'react-native';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -43,13 +44,17 @@ const Interceptor = ({children}: PropsWithChildren<{}>) => {
       async error => {
         const {
           config,
-          response: {status},
+          response: {status, data},
         } = error;
         if (status === 403) {
           const originalHeader = config;
           const refreshToken = await EncryptedStorage.getItem('refreshToken');
           if (!refreshToken) {
             return;
+          }
+          if (data.code === -100012) {
+            EncryptedStorage.removeItem('refreshToken');
+            Alert.alert('로그인이 만료되어 재로그인이 필요합니다.');
           }
           const newAccessToken = await getAccessToken(refreshToken);
           originalHeader.headers.Authorization = `Bearer ${newAccessToken}`;

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,33 @@
+import {GoogleSignin} from '@react-native-google-signin/google-signin';
+import {logout} from '@react-native-seoul/kakao-login';
+import EncryptedStorage from 'react-native-encrypted-storage/';
+import {useQueryClient} from 'react-query';
+import {useDispatch, useSelector} from 'react-redux';
+
+import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
+import {RootState} from 'src/redux/store';
+
+const useLogout = () => {
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
+  const {userInfo} = useSelector((state: RootState) => state.userReducer);
+
+  const signOut = async () => {
+    const provider = userInfo?.provider;
+    if (provider === 'GOOGLE') {
+      await GoogleSignin.signOut();
+    } else if (provider === 'KAKAO') {
+      await logout();
+    } else if (provider === 'APPLE') {
+    }
+    await EncryptedStorage.removeItem('refreshToken');
+    dispatch(setAccessToken(''));
+    dispatch(changeUserInfo({}));
+    dispatch(loginAction(false));
+    queryClient.invalidateQueries();
+  };
+
+  return signOut;
+};
+
+export default useLogout;


### PR DESCRIPTION
## Summary

- 안드로이드 다크모드 비활성화
- AppInner 에서 user를 받아오지 못하고 catch 되었을 때 역시 스플래시 이미지를 감추도록 수정
- 기존 '알 수 없는 유저' 라고 뜨는 로그인은 모두 로그아웃 되도록 수정
- useLogout 커스텀 훅으로 logout 로직이 중복되지 않도록 수정

## Comments

- 빌드 이후에 안드로이드 에뮬레이터에서 wifi Connected, no internet 문제가 있어 테스트를 못했습니다.
- PR 읽어보시고 테스트 한 번 부탁드려요 ㅜㅡㅜ