### PR TITLE
[#250] 지도 페이지 brand filter 버그 수정 및 bottom sheet 로직 변경

### DIFF
--- a/src/components/Booth/MapBottomSheetOrganism/MapBottomSheetOrganism.tsx
+++ b/src/components/Booth/MapBottomSheetOrganism/MapBottomSheetOrganism.tsx
@@ -1,6 +1,6 @@
 import BottomSheet, {BottomSheetFlatList} from '@gorhom/bottom-sheet';
 import {useHeaderHeight} from '@react-navigation/elements';
-import React, {useMemo, useRef} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import {type Coord} from 'react-native-nmap';
 import {getStatusBarHeight} from 'react-native-status-bar-height';
@@ -39,6 +39,25 @@ const MapBottomSheetOrganism = () => {
   const focusedBooth = useSelector((state: RootState) => state.mapReducer.focusBooth);
   const initCoord: Coord = {longitude: 0, latitude: 0};
   const {data} = useGetPhotoBoothLocation({coord: initCoord});
+  const [filteredBoothData, setFilteredBoothData] = useState<PhotoBoothContentData[]>();
+
+  useEffect(() => {
+    const filteringData = async () => {
+      if (!data?.data || !focusedBooth) {
+        return;
+      }
+      const changeData = await [
+        focusedBooth,
+        ...data?.data.content.filter((item: PhotoBoothContentData) => {
+          if (item !== focusedBooth) {
+            return item;
+          }
+        }),
+      ];
+      setFilteredBoothData(changeData);
+    };
+    filteringData();
+  }, [focusedBooth]);
 
   return (
     <BottomSheetConatiner>
@@ -51,14 +70,10 @@ const MapBottomSheetOrganism = () => {
         index={sheetIndex}>
         {data?.data.content.length > 0 ? (
           <BottomSheetFlatList
-            data={data?.data.content}
+            data={filteredBoothData}
             renderItem={({item, index}: {item: PhotoBoothContentData; index: number}) => {
               return index === 0 ? (
-                focusedBooth !== null ? (
-                  <BoothSummaryView {...focusedBooth} />
-                ) : (
-                  <BoothSummaryView {...item} />
-                )
+                focusedBooth && <BoothSummaryView {...focusedBooth} />
               ) : item.photoBooth.id !== focusedBooth?.photoBooth.id ? (
                 <BoothSummaryView {...item} />
               ) : (

--- a/src/redux/reducers/mapReducer.ts
+++ b/src/redux/reducers/mapReducer.ts
@@ -43,9 +43,15 @@ const mapReducer: Reducer = (state = initialState, action) => {
         boothData: payload.booth,
       };
     case CHANGE_FILTER.BRANDS:
+      if (payload.target === parseInt(Object.keys(state.filteredBrand)[0], 10)) {
+        return {
+          ...state,
+          filteredBrand: initialState.filteredBrand,
+        };
+      }
       return {
         ...state,
-        filteredBrand: toggleTag({...initialState.filteredBrand}, payload.target),
+        filteredBrand: toggleTag(initialState.filteredBrand, payload.target),
       };
     case CHANGE_FILTER.TAG:
       return {...state, filteredTag: toggleTag(state.filteredTag, payload.target)};


### PR DESCRIPTION
## Summary
- 지도 페이지 내 brand filter를 여러개에서 하나로 수정하는 과정에서 생긴 버그를 해결했습니다. (하나 선택시 다른거로 변경은 가능한데, 해제가 안되는 문제가 있었음)
- 지도 페이지 바텀 시트에서 foucedBooth 값이 다른 거로 바뀌면 첫 focused booth로 지정된 부스가 바텀 시트에서 사라지는 버그를 고쳤습니다.

## Comments
- 굉장히 간단히 해결 할 수 있는 문제들인데, 바보같이 생각해서 좀 걸렸네요