### PR TITLE
[#269] 로그인 & 로그아웃 시 추천 스크린 Post 좋아요 업데이트 안되는 문제 해결

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import {QueryClient, QueryClientProvider} from 'react-query';
 import {Provider} from 'react-redux';
 
 import AppInner from 'AppInner';
+import UserProvider from 'src/components/UserProvider';
 import {Interceptor} from 'src/components/utils/Interceptor';
 import store from 'src/redux/store';
 import RouteLoginScreen from 'src/screens/LoginScreen';
@@ -28,15 +29,17 @@ const App = () => {
     <QueryClientProvider client={new QueryClient()}>
       <ThemeProvider theme={theme}>
         <Provider store={store}>
-          <Interceptor>
-            <NavigationContainer theme={GlobalStyle}>
-              <Stack.Navigator screenOptions={{headerShown: false}} initialRouteName="AppInner">
-                <Stack.Screen name="AppInner" component={AppInner} />
-                <Stack.Screen name="RouteLoginScreen" component={RouteLoginScreen} />
-                <Stack.Screen name="InitPermissionScreen" component={PermissionScreen} />
-              </Stack.Navigator>
-            </NavigationContainer>
-          </Interceptor>
+          <UserProvider>
+            <Interceptor>
+              <NavigationContainer theme={GlobalStyle}>
+                <Stack.Navigator screenOptions={{headerShown: false}} initialRouteName="AppInner">
+                  <Stack.Screen name="AppInner" component={AppInner} />
+                  <Stack.Screen name="RouteLoginScreen" component={RouteLoginScreen} />
+                  <Stack.Screen name="InitPermissionScreen" component={PermissionScreen} />
+                </Stack.Navigator>
+              </NavigationContainer>
+            </Interceptor>
+          </UserProvider>
         </Provider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -1,19 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {GoogleSignin} from '@react-native-google-signin/google-signin';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {useNavigation} from '@react-navigation/native';
 import React, {useEffect} from 'react';
-import {Config} from 'react-native-config';
-import EncryptedStorage from 'react-native-encrypted-storage';
-import SplashScreen from 'react-native-splash-screen';
-import {useDispatch, useSelector} from 'react-redux';
 
-import getAccessToken from 'src/apis/getAccessToken';
-import getUser from 'src/apis/getUser';
 import TabBar from 'src/components/utils/TabBar';
-import useLogout from 'src/hooks/useLogout';
-import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
-import {RootState} from 'src/redux/store';
 import RouteBoothScreen from 'src/screens/BoothScreen';
 import RouteRecommendScreen from 'src/screens/RecommendScreen';
 import RouteRecordScreen from 'src/screens/RecordScreen';
@@ -22,32 +12,9 @@ import StorageScreen from 'src/screens/StorageScreen/StorageScreen';
 const Tab = createBottomTabNavigator();
 
 const AppInner = () => {
-  const dispatch = useDispatch();
   const navigation = useNavigation();
-  const logout = useLogout();
-  const {isSettingInterceptor} = useSelector((state: RootState) => state.userReducer);
 
   useEffect(() => {
-    GoogleSignin.configure({
-      iosClientId: Config.IOS_GOOGLE_API_KEY,
-    });
-    const getToken = async () => {
-      try {
-        const token = await EncryptedStorage.getItem('refreshToken');
-        if (!token) {
-          SplashScreen.hide();
-          return;
-        }
-        dispatch(loginAction(true));
-        SplashScreen.hide();
-
-        const newAccessToken = await getAccessToken(token);
-        dispatch(setAccessToken(newAccessToken));
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    getToken();
     AsyncStorage.getItem('alreadyLaunched').then(value => {
       if (value == null) {
         AsyncStorage.setItem('alreadyLaunched', 'true');
@@ -55,25 +22,6 @@ const AppInner = () => {
       }
     });
   }, []);
-
-  useEffect(() => {
-    if (!isSettingInterceptor) {
-      return;
-    }
-    const getUserData = async () => {
-      try {
-        const user = await getUser();
-        if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
-          logout();
-        }
-        dispatch(changeUserInfo(user));
-        SplashScreen.hide();
-      } catch (error) {
-        SplashScreen.hide();
-      }
-    };
-    getUserData();
-  }, [isSettingInterceptor]);
 
   return (
     <Tab.Navigator screenOptions={{headerShown: false}} tabBar={props => <TabBar {...props} />}>

--- a/src/components/Recommend/FrameOrganism/FrameOrganism.tsx
+++ b/src/components/Recommend/FrameOrganism/FrameOrganism.tsx
@@ -1,6 +1,6 @@
 import {useNavigation} from '@react-navigation/native';
-import React from 'react';
-import {useDispatch} from 'react-redux';
+import React, {useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
 
 import {ButtonText, TextnIconWrapper} from '../PoseOrganism/PoseOrganism.styles';
 import RecommendPreviewFourCard from '../PreviewSixCard';
@@ -16,15 +16,26 @@ import {
 
 import useGetInfinitePosts from 'src/querys/useGetInfinitePosts';
 import {changeFilteredFrame} from 'src/redux/actions/PostAction';
+import {RootState} from 'src/redux/store';
 
 const FrameRecommendOrganism = () => {
   const dispatch = useDispatch();
-  const {data, isLoading} = useGetInfinitePosts({tagIdSet: [41], order: 'popular', key: 'frame'});
+  const {accessToken} = useSelector((state: RootState) => state.userReducer);
+  const {data, isLoading, refetch} = useGetInfinitePosts({
+    tagIdSet: [41],
+    order: 'popular',
+    key: 'frame',
+  });
   const navigation = useNavigation();
 
   const handlePressCard = (id: number) => () => {
     navigation.navigate('RecommendDetail' as never, {postId: id} as never);
   };
+
+  useEffect(() => {
+    refetch();
+  }, [accessToken]);
+
   return (
     <OrganismView>
       <TitleWrapper>

--- a/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
+++ b/src/components/Recommend/PoseOrganism/PoseOrganism.tsx
@@ -20,8 +20,8 @@ import useGetInfinitePosts from 'src/querys/useGetInfinitePosts';
 import {RootState} from 'src/redux/store';
 
 const PoseRecommendOrganism = () => {
+  const {accessToken} = useSelector((state: RootState) => state.userReducer);
   const {data, isLoading, refetch} = useGetInfinitePosts({order: 'popular', key: 'pose'});
-  const {isSettingInterceptor} = useSelector((state: RootState) => state.userReducer);
   const navigation = useNavigation();
   const handlePressCard = (id: number) => () => {
     navigation.navigate('RecommendDetail' as never, {postId: id} as never);
@@ -29,7 +29,7 @@ const PoseRecommendOrganism = () => {
 
   useEffect(() => {
     refetch();
-  }, [isSettingInterceptor]);
+  }, [accessToken]);
 
   return (
     <OrganismView>

--- a/src/components/UserProvider/UserProvider.tsx
+++ b/src/components/UserProvider/UserProvider.tsx
@@ -1,0 +1,59 @@
+import {GoogleSignin} from '@react-native-google-signin/google-signin';
+import React, {PropsWithChildren, useEffect} from 'react';
+import {Config} from 'react-native-config';
+import EncryptedStorage from 'react-native-encrypted-storage';
+import SplashScreen from 'react-native-splash-screen';
+import {useDispatch} from 'react-redux';
+
+import getAccessToken from 'src/apis/getAccessToken';
+import getUser from 'src/apis/getUser';
+import useLogout from 'src/hooks/useLogout';
+import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
+
+const UserProvider = ({children}: PropsWithChildren<{}>) => {
+  const dispatch = useDispatch();
+  const logout = useLogout();
+
+  useEffect(() => {
+    GoogleSignin.configure({
+      iosClientId: Config.IOS_GOOGLE_API_KEY,
+    });
+    const getToken = async () => {
+      try {
+        const token = await EncryptedStorage.getItem('refreshToken');
+        if (!token) {
+          SplashScreen.hide();
+          return;
+        }
+        dispatch(loginAction(true));
+        SplashScreen.hide();
+
+        const newAccessToken = await getAccessToken(token);
+        dispatch(setAccessToken(newAccessToken));
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getToken();
+  }, []);
+
+  useEffect(() => {
+    const getUserData = async () => {
+      try {
+        const user = await getUser();
+        if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
+          logout();
+        }
+        dispatch(changeUserInfo(user));
+        SplashScreen.hide();
+      } catch (error) {
+        SplashScreen.hide();
+      }
+    };
+    getUserData();
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default UserProvider;

--- a/src/components/UserProvider/index.ts
+++ b/src/components/UserProvider/index.ts
@@ -1,0 +1,3 @@
+import UserProvider from './UserProvider';
+
+export default UserProvider;

--- a/src/components/utils/Interceptor/index.tsx
+++ b/src/components/utils/Interceptor/index.tsx
@@ -5,7 +5,7 @@ import EncryptedStorage from 'react-native-encrypted-storage';
 import {useDispatch, useSelector} from 'react-redux';
 
 import getAccessToken from 'src/apis/getAccessToken';
-import {loginAction, setAccessToken, setInterceptor} from 'src/redux/actions/UserAction';
+import {loginAction, setAccessToken} from 'src/redux/actions/UserAction';
 import {RootState} from 'src/redux/store';
 import getApiServer from 'src/utils/getApiServer';
 
@@ -17,60 +17,55 @@ const Interceptor = ({children}: PropsWithChildren<{}>) => {
   const dispatch = useDispatch();
   const {accessToken} = useSelector((state: RootState) => state.userReducer);
 
-  useEffect(() => {
-    if (!accessToken) {
-      return;
-    }
-
-    const requestInterceptor = AxiosInstance.interceptors.request.use(
-      config => {
-        if (!config.headers) {
-          return config;
-        }
-
-        if (accessToken) {
-          config.headers.Authorization = `Bearer ${accessToken}`;
-        }
+  const requestInterceptor = AxiosInstance.interceptors.request.use(
+    config => {
+      if (!config.headers) {
         return config;
-      },
-      error => {
-        return Promise.reject(error);
-      },
-    );
-    const responseInterceptor = AxiosInstance.interceptors.response.use(
-      response => {
-        return response;
-      },
-      async error => {
-        const {
-          config,
-          response: {status, data},
-        } = error;
-        if (status === 403) {
-          const originalHeader = config;
-          const refreshToken = await EncryptedStorage.getItem('refreshToken');
-          if (!refreshToken) {
-            return;
-          }
-          if (data.code === -100012) {
-            EncryptedStorage.removeItem('refreshToken');
-            Alert.alert('로그인이 만료되어 재로그인이 필요합니다.');
-          }
-          const newAccessToken = await getAccessToken(refreshToken);
-          originalHeader.headers.Authorization = `Bearer ${newAccessToken}`;
-          dispatch(setAccessToken(newAccessToken));
-          dispatch(loginAction(true));
-          return axios(originalHeader);
+      }
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+      return config;
+    },
+    error => {
+      return Promise.reject(error);
+    },
+  );
+  const responseInterceptor = AxiosInstance.interceptors.response.use(
+    response => {
+      return response;
+    },
+    async error => {
+      const {
+        config,
+        response: {status, data},
+      } = error;
+      if (status === 403) {
+        const originalHeader = config;
+        const refreshToken = await EncryptedStorage.getItem('refreshToken');
+        if (!refreshToken) {
+          return;
         }
-        return Promise.reject(error);
-      },
-    );
-    dispatch(setInterceptor());
+        if (data.code === -100012) {
+          EncryptedStorage.removeItem('refreshToken');
+          Alert.alert('로그인이 만료되어 재로그인이 필요합니다.');
+        }
+        const newAccessToken = await getAccessToken(refreshToken);
+        originalHeader.headers.Authorization = `Bearer ${newAccessToken}`;
+        dispatch(setAccessToken(newAccessToken));
+        dispatch(loginAction(true));
+        return axios(originalHeader);
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  useEffect(() => {
     return () => {
       AxiosInstance.interceptors.request.eject(requestInterceptor);
       AxiosInstance.interceptors.response.eject(responseInterceptor);
     };
-  }, [accessToken]);
+  });
 
   return <>{children}</>;
 };

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,7 +1,6 @@
 import {GoogleSignin} from '@react-native-google-signin/google-signin';
 import {logout} from '@react-native-seoul/kakao-login';
-import EncryptedStorage from 'react-native-encrypted-storage/';
-import {useQueryClient} from 'react-query';
+import EncryptedStorage from 'react-native-encrypted-storage';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
@@ -9,7 +8,6 @@ import {RootState} from 'src/redux/store';
 
 const useLogout = () => {
   const dispatch = useDispatch();
-  const queryClient = useQueryClient();
   const {userInfo} = useSelector((state: RootState) => state.userReducer);
 
   const signOut = async () => {
@@ -24,7 +22,6 @@ const useLogout = () => {
     dispatch(setAccessToken(''));
     dispatch(changeUserInfo({}));
     dispatch(loginAction(false));
-    queryClient.invalidateQueries();
   };
 
   return signOut;

--- a/src/redux/actions/UserAction.ts
+++ b/src/redux/actions/UserAction.ts
@@ -1,4 +1,4 @@
-import {LOGIN, USER_INFO, SET_ACCESS_TOKEN, SET_INTERCEPTOR} from '../types/UserActionType';
+import {LOGIN, USER_INFO, SET_ACCESS_TOKEN} from '../types/UserActionType';
 
 import {User} from 'src/types';
 
@@ -15,8 +15,4 @@ export const changeUserInfo = (userInfo: User | {}) => ({
 export const setAccessToken = (accessToken: string) => ({
   type: SET_ACCESS_TOKEN,
   payload: {accessToken},
-});
-
-export const setInterceptor = () => ({
-  type: SET_INTERCEPTOR,
 });

--- a/src/redux/reducers/userReducer.ts
+++ b/src/redux/reducers/userReducer.ts
@@ -1,10 +1,9 @@
 import {Reducer} from 'redux';
 
-import {LOGIN, USER_INFO, SET_ACCESS_TOKEN, SET_INTERCEPTOR} from '../types/UserActionType';
+import {LOGIN, USER_INFO, SET_ACCESS_TOKEN} from '../types/UserActionType';
 
 const initialState = {
   isLoggedIn: false,
-  isSettingInterceptor: false,
   accessToken: '',
   userInfo: {},
 };
@@ -19,8 +18,6 @@ const tabBarReducer: Reducer = (state = initialState, action) => {
       return {...state, userInfo: {...payload.userInfo}};
     case SET_ACCESS_TOKEN:
       return {...state, accessToken: payload.accessToken};
-    case SET_INTERCEPTOR:
-      return {...state, isSettingInterceptor: true};
     default:
       return state;
   }

--- a/src/redux/types/UserActionType.ts
+++ b/src/redux/types/UserActionType.ts
@@ -1,4 +1,3 @@
 export const LOGIN = 'LOGIN';
 export const USER_INFO = 'USER_INFO';
 export const SET_ACCESS_TOKEN = 'SET_ACCESS_TOKEN';
-export const SET_INTERCEPTOR = 'SET_INTERCEPTOR';


### PR DESCRIPTION
## Summary

- AppInner 로직 UserProvider로 분리 (isSettingInterceptor state 제거해도 실행 순서 보장되도록 구현)
- Interceptor에서 requestInterceptor, responseInterceptor 등록 부분을 useEffect 밖으로 옮김으로써, 추천 스크린 API 요청 이전에 Interceptor 등록이 이루어질 수 있도록 수정
- Interceptor useEffect deps 삭제 (eject 되지 않으면, 로그인 & 로그아웃 시에 Interceptor가 업데이트 되지 않는 문제가 있었음)

## Comments

- 로그인, 로그아웃 시에 추천 스크린 업데이트 되는 거 확인했습니다 :)