### PR TITLE
[#290] 신고 버튼 UI 구현 및 기능 추가

### DIFF
--- a/src/apis/mutatePostReport.ts
+++ b/src/apis/mutatePostReport.ts
@@ -1,0 +1,12 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const mutatePostReport = async (id: number) => {
+  try {
+    const result = await AxiosInstance.post(`/api/v1/post/${id}/report`);
+    return result.data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+export default mutatePostReport;

--- a/src/components/utils/ReviewSummary/ReviewSummary.styles.tsx
+++ b/src/components/utils/ReviewSummary/ReviewSummary.styles.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/native';
 import {StyleSheet} from 'react-native';
 
-import {BodyText4, BodyText6} from '../Text';
+import {BodyText4, BodyText5, BodyText6} from '../Text';
 
 import {heightPercentage, widthPercentage} from 'src/styles/ScreenResponse';
 import theme from 'src/styles/Theme';
@@ -26,6 +26,13 @@ export const RowView = styled.View({
 
 export const UserName = styled(BodyText4)({
   color: theme.colors.grayscale[7],
+});
+
+export const ReportButton = styled(BodyText5)({
+  color: theme.colors.grayscale[5],
+  textDecorationLine: 'underline',
+  position: 'absolute',
+  right: 0,
 });
 
 export const CreatedAt = styled(BodyText6)({

--- a/src/components/utils/ReviewSummary/ReviewSummary.tsx
+++ b/src/components/utils/ReviewSummary/ReviewSummary.tsx
@@ -12,6 +12,7 @@ import {
   CreatedAt,
   DropdownWrapper,
   ImageContainer,
+  ReportButton,
   RowView,
   style,
   TagContainer,
@@ -22,6 +23,7 @@ import {
 } from './ReviewSummary.styles';
 
 import {Review} from 'src/types';
+import report from 'src/utils/report';
 import toDateFormat from 'src/utils/toDateFormat';
 
 interface MenuItem {
@@ -42,10 +44,17 @@ const ReviewSummary = ({menuItems, ...props}: Props) => {
   const isExistImage = props.reviewImageSet.length <= 0;
   const isExistTag = props.reviewTagSet.length <= 0;
 
+  const handleReport = () => {
+    report({type: 'review', targetId: props.id});
+  };
+
   return (
     <TouchableWithoutFeedback onPress={() => setIsOpenDropdown(false)}>
       <Container isLast={props.isLast}>
-        <UserName>@{props.user.name}</UserName>
+        <RowView>
+          <UserName>@{props.user.name}</UserName>
+          <ReportButton onPress={handleReport}>신고</ReportButton>
+        </RowView>
         <RowView>
           <StarBox score={props.starScore} />
           <CreatedAt>{toDateFormat(new Date(props.createdAt))}</CreatedAt>

--- a/src/screens/RecommendScreen/RecommendDetailScreen.header.tsx
+++ b/src/screens/RecommendScreen/RecommendDetailScreen.header.tsx
@@ -11,6 +11,7 @@ import useDeletePost from 'src/querys/useDeletePost';
 import useGetPost from 'src/querys/useGetPost';
 import {startModifyPost} from 'src/redux/actions/PostWriteAction';
 import {RootState} from 'src/redux/store';
+import report from 'src/utils/report';
 
 interface Props {
   navigation: NativeStackNavigationProp<RecommendParamList, 'RecommendDetail', undefined>;
@@ -58,10 +59,14 @@ const RecommendDetailScreenHeader = ({navigation, postId, isRecord, isStorage}: 
       },
     });
   };
-  const menuItem = [
+  const handleReport = () => {
+    report({type: 'post', targetId: postId});
+  };
+  const myMenuItem = [
     {name: '수정', onPressItem: handleModifyPost},
     {name: '삭제', onPressItem: handleDeletePost},
   ];
+  const diffUserMenuItem = [{name: '게시물 신고', onPressItem: handleReport}];
 
   useEffect(() => {
     const handler = () => {
@@ -75,7 +80,7 @@ const RecommendDetailScreenHeader = ({navigation, postId, isRecord, isStorage}: 
   return (
     <LeftBackHeader
       onPressBack={goBack}
-      menuItems={data?.user.id === userInfo.id ? menuItem : undefined}
+      menuItems={data?.user.id === userInfo.id ? myMenuItem : diffUserMenuItem}
     />
   );
 };

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -1,6 +1,8 @@
 import {Alert} from 'react-native';
 import Mailer from 'react-native-mail';
 
+import mutatePostReport from 'src/apis/mutatePostReport';
+
 interface Parameter {
   type: 'post' | 'review';
   targetId: number;
@@ -27,7 +29,15 @@ const report = ({type, targetId}: Parameter) => {
       body: description,
     },
     (error, event) => {
-      Alert.alert(error, event, [], {cancelable: true});
+      if (error) {
+        return Alert.alert(error, event, [], {cancelable: true});
+      }
+      if (type === 'post') {
+        return mutatePostReport(targetId);
+      }
+      if (type === 'review') {
+        return;
+      }
     },
   );
 };

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -7,15 +7,26 @@ interface Parameter {
 }
 
 const report = ({type, targetId}: Parameter) => {
+  const description = `이 게시물을 신고하는 이유를 알려주세요.
+
+  포톡스 팀에서 해당 유저 및 콘텐츠의 커뮤니티 가이드 위반 여부를 판단하여 적절한 조치를 취하도록 하겠습니다. 내용을 자세히 작성해 주시면 해당 문제를 더 빠르게 해결 할 수 있습니다.
+  
+  ex)
+  지나친 상업적 홍보 내용으로 신고합니다.
+  도배 콘텐츠로 신고합니다.
+  저작권에 침해되는 게시물입니다.
+  
+  *신고는 익명으로 접수 되며 상대방에게 신고 정보를 알리지 않습니다.`;
+
   Mailer.mail(
     {
       subject: `Photalks ${type} Report #${targetId}`,
       recipients: ['hot6.developer@gmail.com'],
       ccRecipients: ['hot6.developer@gmail.com'],
       bccRecipients: ['hot6.developer@gmail.com'],
+      body: description,
     },
     (error, event) => {
-      console.log(error);
       Alert.alert(error, event, [], {cancelable: true});
     },
   );


### PR DESCRIPTION
## Summary

- 신고 버튼 클릭 시 report 유틸 함수 호출하여 메일을 보낼 수 있는 페이지로 이동
- figma 참고하여 mail body 자동으로 입력되도록 구현

## Comments

- 현재 사용중인 Mail 라이브러리가 메일을 성공적으로 보낼 경우 안드로이드에서 그에 대한 callback을 사용할 수 없습니다.
- 그렇게 되면 성공적인 처리 후 Toast 메시지를 띄우는 동작을 구현하는 것이 불가능해집니다.
- deep linking 이라는 기술이 따로 있어 라이브러리를 사용하지 않고 해당 기술로 처리할 수 있을 것 같은데 좀 더 서치 후에 사용해야할 것 같습니다.
- 현재는 토스트까지 구현되진 않은 상태입니다.
- 백엔드 신고 api 추가 시 업데이트 하겠습니다.