### PR TITLE
[#292] 약관 동의 api 연동

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -10,15 +10,21 @@ interface LoginParam {
 }
 
 const login = async (loginBridge: () => Promise<LoginParam>) => {
+  const {email, provider, providerId} = await loginBridge().catch(error => Promise.reject(error));
+
   try {
-    const {email, provider, providerId} = await loginBridge();
     const params = `email=${email}&providerId=${providerId}&provider=${provider}`;
     const result = await axios.get(`${getApiServer}/api/v1/user/login?${params}`);
     return result.data;
   } catch (error) {
-    //@ts-ignore
-    if (error.response.data.code === -100010) {
-      Alert.alert('탈퇴된 회원이거나 접근 할 수 없는 계정입니다.');
+    const err = error as any;
+    if (err.response.data.code === -100010) {
+      Alert.alert(err.message);
+    }
+    if (err.response.data.code === -100015) {
+      Alert.alert(err.message);
+      err.email = email;
+      throw err;
     }
     return Promise.reject(error);
   }

--- a/src/apis/putAgreeTerm.ts
+++ b/src/apis/putAgreeTerm.ts
@@ -1,0 +1,7 @@
+import AxiosInstance from 'src/components/utils/Interceptor';
+
+const putAgreeTerm = async (email: string) => {
+  AxiosInstance.patch('/api/v1/agree-term', {email});
+};
+
+export default putAgreeTerm;

--- a/src/components/Login/LoginOrganism/LoginOrganism.tsx
+++ b/src/components/Login/LoginOrganism/LoginOrganism.tsx
@@ -24,6 +24,7 @@ import login from 'src/apis/login';
 import useLogout from 'src/hooks/useLogout';
 import {changeUserInfo, loginAction, setAccessToken} from 'src/redux/actions/UserAction';
 import {heightPercentage} from 'src/styles/ScreenResponse';
+import {User} from 'src/types';
 import valueOfPlatform from 'src/utils/valueOfPlatform';
 
 const LoginOrganism = () => {
@@ -32,16 +33,24 @@ const LoginOrganism = () => {
   const dispatch = useDispatch();
 
   const handleLogin = (bridge: any) => async () => {
-    const token = await login(bridge);
-    EncryptedStorage.setItem('refreshToken', token.refreshToken);
-    dispatch(setAccessToken(token.token));
-    const user = await getUser(token.token);
-    if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
-      logout();
+    let user: User;
+    try {
+      const token = await login(bridge);
+      EncryptedStorage.setItem('refreshToken', token.refreshToken);
+      dispatch(setAccessToken(token.token));
+      user = await getUser(token.token);
+      if (!['KAKAO', 'APPLE', 'GOOGLE'].includes(user.provider)) {
+        logout();
+      }
+      dispatch(changeUserInfo(user));
+      dispatch(loginAction(true));
+      navigation.goBack();
+    } catch (err: any) {
+      //@ts-ignore
+      if (error.response.data.code === -100015) {
+        navigation.navigate('InitTermsScreen' as never, {email: err.email} as never);
+      }
     }
-    dispatch(changeUserInfo(user));
-    dispatch(loginAction(true));
-    navigation.goBack();
   };
 
   return (

--- a/src/components/Terms/TermsOrganism/TermsOrganism.tsx
+++ b/src/components/Terms/TermsOrganism/TermsOrganism.tsx
@@ -1,4 +1,4 @@
-import {useNavigation} from '@react-navigation/native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -22,6 +22,7 @@ import {
   TitleBold,
 } from './TermsOrganism.styles';
 
+import putAgreeTerm from 'src/apis/putAgreeTerm';
 import requestcameraPermission from 'src/hooks/requestcameraPermission';
 import requestLocationPermission from 'src/hooks/requestLocationPermission';
 import {
@@ -30,15 +31,18 @@ import {
   changeServiceTerms,
 } from 'src/redux/actions/TermsAction';
 import {RootState} from 'src/redux/store';
+import {TermsParamList} from 'src/screens/TermsScreen/TermsScreen';
 
-const TermsOrganism = () => {
-  const navigation = useNavigation();
+export type TermsScreenProps = NativeStackScreenProps<TermsParamList, 'TermsScreen'>;
+
+const TermsOrganism = ({navigation, route}: TermsScreenProps) => {
   const dispatch = useDispatch();
   const {serviceTerms, privacyTerms, locationTerms} = useSelector(
     (state: RootState) => state.termsReducer,
   );
 
   const nextHandler = () => {
+    putAgreeTerm(route.params.email);
     requestcameraPermission().then(() =>
       requestLocationPermission().then(() => navigation.navigate('AppInner' as never)),
     );

--- a/src/screens/TermsScreen/TermsScreen.tsx
+++ b/src/screens/TermsScreen/TermsScreen.tsx
@@ -7,6 +7,11 @@ import ServiceTermsOrganism from 'src/components/Terms/ServiceTermsOrganism';
 import TermsOrganism from 'src/components/Terms/TermsOrganism';
 
 const Stack = createNativeStackNavigator();
+
+export type TermsParamList = {
+  TermsScreen: {email: string};
+};
+
 const TermsScreen = () => {
   return (
     <Stack.Navigator screenOptions={{headerShown: false}} initialRouteName="TermsScreen">


### PR DESCRIPTION
## Summary

- login 시 error를 catch 하여 약관 동의에 관한 error code 와 일치할 시 navigate 하도록 구현 (email을 param으로 넘김)
- 약관 동의 페이지에서 제출 시 putAgreeTerm 호출하여 약관 동의 여부 업데이트

## Comments

- 백엔드 develop 실행 오류 수정 및 배포 이후 다시 테스트가 필요합니다.